### PR TITLE
add find_country_by_name method, use downcase in find methods

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -70,9 +70,15 @@ class ISO3166::Country
     end
 
     def find_by_name(name)
+      name.downcase!
       Data.select do |k,v|
-        v["name"] == name || v["names"].include?(name)
+        v["name"].downcase == name || v["names"].map{ |name| name.downcase }.include?(name)
       end.first
+    end
+
+    def find_country_by_name(name)
+      result = self.find_by_name(name)
+      result ? self.new(result.first) : nil
     end
   end
 end

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe ISO3166::Country do
@@ -160,10 +162,44 @@ describe ISO3166::Country do
       its(:first) { should == "PL" }
     end
 
+    context "when search lowercase name in 'name'" do
+      subject { ISO3166::Country.find_by_name("poland") }
+
+      its(:first) { should == "PL" }
+    end
+
     context "when search name in 'names'" do
       subject { ISO3166::Country.find_by_name("Polonia") }
 
       its(:first) { should == "PL" }
+    end
+  end
+
+  describe ".find_country_by_name" do
+    context "when search name found" do
+      let(:uk) { ISO3166::Country.find_country_by_name("United Kingdom") }
+
+      it "should be a country instance" do
+        uk.should be_a(ISO3166::Country)
+        uk.alpha2.should == "GB"
+      end
+    end
+
+    context "when search lowercase name found" do
+      let(:uk) { ISO3166::Country.find_country_by_name("united kingdom") }
+
+      it "should be a country instance" do
+        uk.should be_a(ISO3166::Country)
+        uk.alpha2.should == "GB"
+      end
+    end
+
+    context "when search name not found" do
+      let(:bogus) { ISO3166::Country.find_country_by_name("Does not exist") }
+
+      it "should be a country instance" do
+        bogus.should == nil
+      end
     end
   end
 


### PR DESCRIPTION
Hi,

Thanks for this gem, it's really great.  Just thought I'd let you know about this change I've made. I thought it was a little weird that the `find_by_name` method returned an array containing the country code and then a hash with all the country data. Maybe this was needed for a specific case? I would expect it to return a Country instance.  Ideally I'd replace the old method, but I've added a separate `find_country_by_name` method to avoid getting in anyone's way.

I also downcased the search term and country name(s) in `find_by_name` to allow for user capitalization mistakes, as I'm pulling in location data from APIs. The usage of this method is unaffected.

I had trouble running the tests at first for some reason – I had to resort to specifying the encoding at the top of the file.

Cheers,

Joe
