### PR TITLE
Added name to authors in gem specification

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ begin
     gem.description = 'All sorts of useful information about every country packaged as pretty little country objects. It includes data from ISO 3166 (countries and subdivisions), ISO 4217 (currency), and E.164 (phone numbers). As a bonus it even adds a country_select helper to rails projects.'
     gem.email = "hexorx@gmail.com"
     gem.homepage = "http://github.com/hexorx/countries"
-    gem.authors = ["hexorx"]
+    gem.authors = ["hexorx", "Joe Corcoran"]
     gem.add_dependency('currencies', '>= 0.2.0')
     gem.add_development_dependency "rspec"
     gem.add_development_dependency "yard"


### PR DESCRIPTION
Hey man,

Unless I'm being silly, I can't see a "contributors" attribute for gem specs, so I've thrown myself into the authors array.

I like the idea of documenting the two gems at your domain, so drop me a message when you have the time and we can talk about it.

Joe
