### PR TITLE
remove single quote escapes from countries data

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -963,9 +963,9 @@ CI:
   international_prefix: "00"
   latitude: "8 00 N"
   longitude: "5 00 W"
-  name: "Côte D\\'Ivoire"
+  name: "Côte D'Ivoire"
   names: 
-    - "Côte D\\'Ivoire"
+    - "Côte D'Ivoire"
   national_destination_code_lengths: 
     - 2
   national_number_lengths: 
@@ -2803,7 +2803,7 @@ LA:
   international_prefix: "00"
   latitude: "18 00 N"
   longitude: "105 00 E"
-  name: "Lao People\\'s Democratic Republic"
+  name: "Lao People's Democratic Republic"
   names: 
     - Laos
     - Laos


### PR DESCRIPTION
2 countries have their single quotes double escaped:

Lao People\\'s Democratic Republic
Côte D\\'Ivoire

Not sure why they are escaped in the first place, assuming its just a mistake.
