### PR TITLE
Update country codes

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -1153,7 +1153,7 @@ CV:
 CX: 
   alpha2: CX
   alpha3: CXR
-  country_code: "618"
+  country_code: "61"
   currency: AUD
   international_prefix: "0011"
   latitude: "10 30 S"
@@ -4043,7 +4043,7 @@ PM:
 PN: 
   alpha2: PN
   alpha3: PCN
-  country_code: "872"
+  country_code: ""
   currency: NZD
   international_prefix: "00"
   latitude: "25 04 S"


### PR DESCRIPTION
Hi,

I've made a few updates to the international dialling code data (country_code in countries.yaml) and wondered if you'd consider adding them in?

Some countries had missing country_code data as follows:

<pre>
IM: Isle of Man (44)
IO: British Indian Ocean Territory (246)
BL: Saint Barthélemy (590)
EH: Western Sahara (212)
GG: Guernsey (44)
JE: Jersey (44)
AQ: Antarctica (672)
MF: Saint Martin (590)
AX: Åland Islands (358)
GS: South Georgia and the South Sandwich Islands (500)
</pre>


and the following weren't right:

<pre>
CX: Christmas Island (change from 610 to 61)
PN: Pitcairn (change from 872 to nothing)
</pre>


The data source I've used is http://en.wikipedia.org/wiki/List_of_country_calling_codes

Thanks very much,

Deb
