### PR TITLE
Makes two Country instances compare as equal if they have the same data

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -42,6 +42,10 @@ class ISO3166::Country
     !!@data
   end
 
+  def ==(other)
+    self.data == other.data
+  end
+
   def currency
     ISO4217::Currency.from_code(@data['currency'])
   end

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -50,6 +50,10 @@ describe ISO3166::Country do
     country.un_locode.should == 'US'
   end
 
+  it 'should be identical to itself' do
+    country.should == ISO3166::Country.search('US')
+  end
+
   describe 'e164' do
     it 'should return country_code' do
       country.country_code.should == '1'


### PR DESCRIPTION
Currently, Country instances cannot be compared to each other because performing two different searches yields two different instances. That is, you get the following very surprising result:

```
Ψ irb
ruby-1.9.2-p290 :001 > require 'countries'
 => true 
ruby-1.9.2-p290 :002 > Country['US'] == Country['US']
 => false 
```

This pull request fixes that problem. A spec is included.

As a future idea, you may also want to consider making Country instances immutable and caching the instances, since `Country[x]` should be an idempotent operation.
