### PR TITLE
Updated currency of Estonia (EE) to EUR (since january 1st, 2011)

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -1507,7 +1507,7 @@ EE:
   alpha2: EE
   alpha3: EST
   country_code: "372"
-  currency: EEK
+  currency: EUR
   international_prefix: "00"
   ioc: EST
   latitude: "59 00 N"


### PR DESCRIPTION
According to http://en.wikipedia.org/wiki/Estonia#Historic_development (end of the second paragraph) Estonia (EE) adopted the EUR currency on Janaury 1st in 2011.
