### PR TITLE
Update lib/data/countries.yaml

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -1664,7 +1664,7 @@ FI:
   country_code: "358"
   currency: EUR
   international_prefix: "00"
-  ioc: 
+  ioc: FIN
   latitude: "64 00 N"
   longitude: "26 00 E"
   name: Finland
@@ -1845,7 +1845,7 @@ GB:
   country_code: "44"
   currency: GBP
   international_prefix: "00"
-  ioc: 
+  ioc: GBR
   latitude: "54 00 N"
   longitude: "2 00 W"
   name: "United Kingdom"
@@ -4048,7 +4048,7 @@ NL:
   country_code: "47"
   currency: NOK
   international_prefix: "00"
-  ioc: NED
+  ioc: NOR
   latitude: "62 00 N"
   longitude: "10 00 E"
   name: Norway
@@ -5336,7 +5336,7 @@ TL:
   country_code: "670"
   currency: IDR
   international_prefix: None
-  ioc: 
+  ioc: TLS
   latitude: "8 50 S"
   longitude: "125 55 E"
   name: Timor-Leste


### PR DESCRIPTION
Updated IOC codes.
 \* Added missing: FIN, GBR, TLS
 * Fixed: NED->NOR
Source: http://en.wikipedia.org/wiki/List_of_IOC_country_codes

You may consider:
 \* adding South Sudan ("South Sudan became an independent state on 9 July 2011.") / Wikipedia), and
 \* removing Netherlands Antilles ("Though the country has dissolved, the islands are all still under the Kingdom with different legal status and the term is still used to refer to these Dutch Caribbean islands." / Wikipedia). 
Athletes from these two places competed at the London 2012 Olympics as Independent Olympic Athletes with IOC code "IOA" and under the Olympic flag.
