### PR TITLE
Country#find_all_by improved

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -95,14 +95,18 @@ class ISO3166::Country
     def find_all_by(attribute, val)
       raise "Invalid attribute name '#{attribute}'" unless AttrReaders.include?(attribute.to_sym)
       attribute = attribute.to_s
-      val       = val.to_s.downcase
+      if val.is_a?(Regexp)
+        val = Regexp.new(val.source, 'i')
+      else
+        val = val.to_s.downcase
+      end
       attribute = ['name', 'names'] if attribute == 'name'
       Data.select do |k,v|
         Array(attribute).map do |attr|
           if v[attr].kind_of?(Enumerable)
-            v[attr].map{ |n| n.downcase }.include?(val)
+            v[attr].any?{ |n| val === n.downcase }
           else
-            v[attr] && v[attr].downcase == val
+            v[attr] && val === v[attr].downcase
           end
         end.uniq.include?(true)
       end

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -216,6 +216,11 @@ describe ISO3166::Country do
       spain_data.keys.should == ['ES']
     end
 
+    it "also performs searches with regexps and forces it to ignore case" do
+      spain_data = ISO3166::Country.find_all_by(:names, /Españ/)
+      spain_data.should be_a Hash
+      spain_data.keys.should == ['ES']
+    end
   end
 
   describe "hash finder methods" do


### PR DESCRIPTION
Country#find_all_by accepts attributes as a symbol, and casts to string values. It also downcases, so dynamic finders dont need to do it.

Now also can get regexps and uses `===` to match the values
