### PR TITLE
Prevent selected from being included twice in the HTML for country selector helper

### DIFF
--- a/lib/countries/select_helper.rb
+++ b/lib/countries/select_helper.rb
@@ -14,6 +14,11 @@ module ActionView
           priority_countries = [*priority_countries].map {|x| [x,ISO3166::Country::NameIndex[x]] }
           country_options += options_for_select(priority_countries, selected)
           country_options += "<option value=\"\" disabled=\"disabled\">-------------</option>\n"
+
+          # prevent selected from being included twice in the HTML which causes
+          # some browsers to select the second selected option (not priority)
+          # which makes it harder to select an alternative priority country
+          selected = nil if priority_countries.include?([ISO3166::Country[selected].name, selected])
         end
 
         country_options = country_options.html_safe if country_options.respond_to?(:html_safe)


### PR DESCRIPTION
prevent selected from being included twice in the HTML which causes
some browsers to select the second selected option (not priority)
which makes it harder to select an alternative priority country

fix taken from https://github.com/jamesds/country-select/blob/master/lib/country-select.rb
