### PR TITLE
Fix country_options_for_select for when selected = nil (the default)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    countries (0.8.4)
+    countries (0.9.1)
       currencies (>= 0.4.0)
 
 GEM

--- a/lib/countries/select_helper.rb
+++ b/lib/countries/select_helper.rb
@@ -7,25 +7,26 @@ module ActionView
         InstanceTag.new(object, method, self, options.delete(:object)).to_country_select_tag(priority_countries, options, html_options)
       end
 
-      def country_options_for_select(selected = nil, priority_countries = nil)
+      def country_options_for_select(selected_country_code = nil, priority_countries = nil)
         country_options = ""
 
         if priority_countries
-          priority_countries = [*priority_countries].map {|x| [x,ISO3166::Country::NameIndex[x]] }
-          country_options += options_for_select(priority_countries, selected)
+          priority_countries = [*priority_countries].map { |x| [x,ISO3166::Country::NameIndex[x]] }
+          country_options += options_for_select(priority_countries, selected_country_code)
           country_options += "<option value=\"\" disabled=\"disabled\">-------------</option>\n"
 
-          # prevent selected from being included twice in the HTML which causes
+          # prevent selected_country_code from being included twice in the HTML which causes
           # some browsers to select the second selected option (not priority)
           # which makes it harder to select an alternative priority country
-          selected = nil if priority_countries.include?([ISO3166::Country[selected].name, selected])
+          if selected_country = ISO3166::Country[selected_country_code]
+            selected_country_code = nil if priority_countries.include?([selected_country.name, selected_country_code])
+          end
         end
 
         country_options = country_options.html_safe if country_options.respond_to?(:html_safe)
+        countries = ISO3166::Country::Names.map{ |(name,alpha2)| [name.html_safe,alpha2] }
 
-        countries = ISO3166::Country::Names.map{|(name,alpha2)| [name.html_safe,alpha2] }
-
-        return country_options + options_for_select(countries, selected)
+        country_options + options_for_select(countries, selected_country_code)
       end
     end
 


### PR DESCRIPTION
Hi!

When `selected` (btw renamed `selected_country_code`),
`ISO3166::Country[selected_country_code]` would return false, hence
`false.name` was failing.

Thank you!
