### PR TITLE
Change 'Viet Nam' to 'Vietnam'.

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -8128,7 +8128,7 @@ VN:
   ioc: VIE
   latitude: "16 10 N"
   longitude: "107 50 E"
-  name: "Viet Nam"
+  name: "Vietnam"
   names:
     - "Vietnam"
   translations:


### PR DESCRIPTION
Why 'Viet Nam' in not Vietnam?
