### PR TITLE
Abbreviations for subdivisions in thailand

### DIFF
--- a/lib/data/subdivisions/TH.yaml
+++ b/lib/data/subdivisions/TH.yaml
@@ -5,8 +5,6 @@
   names:
     - "Krung Thep"
     - Bangkok
-    - Bangkok
-    - Bangkok
     - "BKK"
 ? "11"
 :


### PR DESCRIPTION
Adds 'BKK' as an abbreviation for Bangkok and removes duplicate entries of 'Bangkok'
