### PR TITLE
Rwanda phone numbers are now 8 and 9 digits long.

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -6912,10 +6912,8 @@ RW:
   national_destination_code_lengths:
   - 2
   national_number_lengths:
-  - 5
-  - 6
-  - 7
   - 8
+  - 9
   national_prefix: '0'
   number: '646'
   region: Africa


### PR DESCRIPTION
Rwanda phone numbers are now 8 and 9 digits long.
See: http://en.wikipedia.org/wiki/Telephone_numbers_in_Rwanda
and http://www.itu.int/oth/T02020000AE/en
