### PR TITLE
Bundle install + Added translation expectation (Bad rubygems versions).

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,3 @@
-GIT
-  remote: git://github.com/dwilkie/currencies.git
-  revision: f6da599e6a6d74b2588806498111970e8dbed090
-  specs:
-    currencies (0.4.0)
-
 PATH
   remote: .
   specs:
@@ -13,6 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    currencies (0.4.2)
     diff-lcs (1.1.3)
     rake (0.9.2.2)
     rspec (2.10.0)
@@ -30,7 +25,7 @@ PLATFORMS
 
 DEPENDENCIES
   countries!
-  currencies!
+  currencies (~> 0.4.2)
   rake
   rspec
   yard

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -26,6 +26,11 @@ describe ISO3166::Country do
     country.names.should == ["United States of America", "Vereinigte Staaten von Amerika", "États-Unis", "Estados Unidos", "アメリカ合衆国"]
   end
 
+  it 'should return translations' do
+    country.translations.should be
+    country.translations["en"].should == "United States of America"
+  end
+
   it 'should return latitude' do
     country.latitude.should == '38 00 N'
   end


### PR DESCRIPTION
0.9.0, 0.9.1, 0.9.2 versions from rubygems differs from github version (and there is only 0.9.1 version) and they has no translations for countries (different countries.yaml). I've added the transations-related expectation which wil fail for those rubygems versions. Github version is ok. Please update your rubygems versions of countries.

Example:

gem uninstall countries
gem install countries
irb
require 'countries'
Country.new("US").translations # NoMethodError: undefined method `translations'

The only working way for me now is to install from github.
