### PR TITLE
Update Mayotte (YT) country code from 269 to 262.

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -8802,7 +8802,7 @@ YT:
   continent: Africa
   alpha2: YT
   alpha3: MYT
-  country_code: '269'
+  country_code: '262'
   currency: EUR
   international_prefix: '00'
   ioc:


### PR DESCRIPTION
Mayotte (YT) country code was changed from 269 to 262 in early 2007.
See http://www.wtng.info/wtng-262-fr.html and
https://en.wikipedia.org/wiki/Telephone_numbers_in_France for details on the switch.
