### PR TITLE
Bangladesh Currency code is BDT

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -698,7 +698,7 @@ BD:
   alpha2: BD
   alpha3: BGD
   country_code: '880'
-  currency: BTD
+  currency: BDT
   international_prefix: '00'
   ioc: BAN
   latitude: 24 00 N


### PR DESCRIPTION
This was updated in the currencies gem and needs to be updated here
hexorx/currencies@2a95dd4692e0aad644c74801385b7b868aa70572
http://www.xe.com/iso4217.php#B
