### PR TITLE
Changes to the country method and correct or supply some missing currencies

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -4,6 +4,7 @@ class ISO3166::Country
   Data = YAML.load_file(File.join(File.dirname(__FILE__), '..', 'data', 'countries.yaml')) || {}
   Names = Data.map {|k,v| [v['name'],k]}.sort_by { |d| d[0] }
   NameIndex = Hash[*Names.flatten]
+  CurrencyProxy = Struct.new(:code, :name, :symbol)
 
   AttrReaders = [
     :number,
@@ -52,7 +53,12 @@ class ISO3166::Country
   end
 
   def currency
-    ISO4217::Currency.from_code(@data['currency'])
+    ccy_code = @data['currency'] || ISO4217::Currency.base_currency
+    if (ccy = ISO4217::Currency.from_code(ccy_code))
+      ccy
+    else
+      CurrencyProxy.new(ccy_code, ccy_code)
+    end
   end
 
   def subdivisions
@@ -113,7 +119,7 @@ class ISO3166::Country
     protected
     def parse_attributes(attribute, val)
       raise "Invalid attribute name '#{attribute}'" unless AttrReaders.include?(attribute.to_sym)
-      
+
       attributes = Array(attribute.to_s)
       attributes << 'names' if attributes == ['name']
 

--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -324,7 +324,7 @@ AQ:
   alpha2: AQ
   alpha3: ATA
   country_code: '672'
-  currency:
+  currency: AUD
   international_prefix: ''
   ioc:
   latitude: 90 00 S
@@ -555,7 +555,7 @@ AX:
   alpha2: AX
   alpha3: ALA
   country_code: '358'
-  currency:
+  currency: EUR
   international_prefix: ''
   ioc:
   latitude: ''
@@ -698,7 +698,7 @@ BD:
   alpha2: BD
   alpha3: BGD
   country_code: '880'
-  currency: BTD
+  currency: BDT
   international_prefix: '00'
   ioc: BAN
   latitude: 24 00 N
@@ -957,7 +957,7 @@ BL:
   alpha2: BL
   alpha3: BLM
   country_code: '590'
-  currency:
+  currency: EUR
   international_prefix: ''
   ioc:
   latitude: 17 90 N
@@ -1406,7 +1406,7 @@ CD:
   alpha2: CD
   alpha3: COD
   country_code: '243'
-  currency:
+  currency: CDF
   international_prefix: '00'
   ioc: COD
   latitude: 0 00 N
@@ -1481,7 +1481,7 @@ CG:
   alpha2: CG
   alpha3: COG
   country_code: '242'
-  currency:
+  currency: XAF
   international_prefix: '00'
   ioc: CGO
   latitude: 1 00 S
@@ -3118,7 +3118,7 @@ GQ:
   alpha2: GQ
   alpha3: GNQ
   country_code: '240'
-  currency:
+  currency: XAF
   international_prefix: '00'
   ioc: GEQ
   latitude: 2 00 N
@@ -3195,7 +3195,7 @@ GS:
   alpha2: GS
   alpha3: SGS
   country_code: '500'
-  currency:
+  currency: GBP
   international_prefix: ''
   ioc:
   latitude: 54 30 S
@@ -5083,7 +5083,7 @@ MG:
   alpha2: MG
   alpha3: MDG
   country_code: '261'
-  currency:
+  currency: MGA
   international_prefix: '00'
   ioc: MAD
   latitude: 20 00 S
@@ -5159,7 +5159,7 @@ MK:
   alpha2: MK
   alpha3: MKD
   country_code: '389'
-  currency:
+  currency: MKD
   international_prefix: '00'
   ioc: MKD
   latitude: 41 50 N
@@ -5301,7 +5301,7 @@ MO:
   alpha2: MO
   alpha3: MAC
   country_code: '853'
-  currency:
+  currency: MOP
   international_prefix: '00'
   ioc:
   latitude: 22 10 N
@@ -6092,7 +6092,7 @@ NU:
   alpha2: NU
   alpha3: NIU
   country_code: '683'
-  currency:
+  currency: NZD
   international_prefix: '00'
   ioc:
   latitude: 19 02 S
@@ -6567,7 +6567,7 @@ PS:
   alpha2: PS
   alpha3: PSE
   country_code: '970'
-  currency:
+  currency: ILS
   international_prefix: '00'
   ioc: PLE
   latitude: ''
@@ -7940,7 +7940,7 @@ TM:
   alpha2: TM
   alpha3: TKM
   country_code: '993'
-  currency:
+  currency: TMT
   international_prefix: '810'
   ioc: TKM
   latitude: 40 00 N
@@ -8657,7 +8657,7 @@ VU:
   alpha2: VU
   alpha3: VUT
   country_code: '678'
-  currency:
+  currency: VUV
   international_prefix: '00'
   ioc: VAN
   latitude: 16 00 S


### PR DESCRIPTION
I suppose the main issue you will have is with the refactored currency method. I'll explain my thinking.

The AttrReader mechanism defines a currency reader method first, then it is redefined.  Perhaps the reader method should have been aliased so one can still get access to the attribute.  However there will be a lot of code out there that uses the second method, so it should return something instead of depending on the Currency gem to be in sync.

I chose to use a CurrencyProxy Struct instead of using an instance of ISO4217::Currency so that one can detect the difference in returned object if needs be.

I set the currency of Antartica to AUD (because Australia seems to have the biggest slice of it), arguably this is not correct.  However many test suites use random selections for countries, causing failures when the currency method returns nil.
