### PR TITLE
Add Dutch Caribbean (former Netherlands Antilles) countries.

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -1116,6 +1116,35 @@ BO:
   - ay
   - qu
   nationality: Bolivian
+BQ:
+  continent: North America
+  alpha2: BQ
+  alpha3: BES
+  country_code: '599'
+  currency: USD
+  international_prefix: '00'
+  latitude: ''
+  longitude: ''
+  name: Bonaire, Sint Eustatius and Saba
+  names:
+  - Bonaire, Sint Eustatius and Saba
+  - Caribbean Netherlands
+  - Caribisch Nederland
+  translations:
+    en: Bonaire, Sint Eustatius and Saba
+  national_destination_code_lengths:
+  - 2
+  national_number_lengths:
+  - 7
+  national_prefix: '0'
+  number: '535'
+  region: Americas
+  subregion: Caribbean
+  un_locode: BQ
+  languages:
+  - nl
+  - en
+  nationality: Dutch
 BR:
   continent: South America
   address_format: |-
@@ -1920,6 +1949,33 @@ CV:
   languages:
   - pt
   nationality: Cape Verdian
+CW:
+  continent: North America
+  alpha2: CW
+  alpha3: CUW
+  country_code: '599'
+  currency: ANG
+  international_prefix: '00'
+  latitude: ''
+  longitude: ''
+  name: Curaçao
+  names:
+  - Curaçao
+  translations:
+    en: Curaçao
+    nl: Curaçao
+  national_destination_code_lengths:
+  - 2
+  national_number_lengths:
+  - 7
+  national_prefix: '0'
+  number: '531'
+  region: Americas
+  subregion: Caribbean
+  un_locode: CW
+  languages:
+  - nl
+  nationality: Dutch
 CX:
   continent: Asia
   alpha2: CX
@@ -7800,6 +7856,34 @@ SV:
   languages:
   - es
   nationality: Salvadoran
+SX:
+  continent: North America
+  alpha2: SX
+  alpha3: SXM
+  country_code: '1'
+  currency: ANG
+  international_prefix: '011'
+  latitude: ''
+  longitude: ''
+  name: Sint Maarten
+  names:
+  - Sint Maarten
+  translations:
+    en: Sint Maarten
+    nl: Sint Maarten
+  national_destination_code_lengths:
+  - 3
+  national_number_lengths:
+  - 10
+  national_prefix: '0'
+  number: '534'
+  region: Americas
+  subregion: Caribbean
+  un_locode: SX
+  languages:
+  - nl
+  - en
+  nationality: Dutch
 SY:
   continent: Asia
   address_format: |-

--- a/lib/data/subdivisions/BQ.yaml
+++ b/lib/data/subdivisions/BQ.yaml
@@ -1,0 +1,10 @@
+---
+BO:
+  name: Bonaire
+  names: Bonaire
+SA:
+  name: Saba
+  names: Saba
+SE:
+  name: "Sint Eustatius"
+  names: "Sint Eustatius"

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -136,7 +136,7 @@ describe ISO3166::Country do
       countries = ISO3166::Country.all
       countries.should be_an(Array)
       countries.first.should be_an(Array)
-      countries.should have(247).countries
+      countries.should have(250).countries
     end
 
     it "should allow to customize each country representation passing a block to the method" do
@@ -144,7 +144,7 @@ describe ISO3166::Country do
       countries.should be_an(Array)
       countries.first.should be_an(Array)
       countries.first.should have(3).fields
-      countries.should have(247).countries
+      countries.should have(250).countries
     end
   end
 


### PR DESCRIPTION
Specifically, add:
- BQ: Bonaire, Sint Eustatius and Saba
- CW: Curaçao
- SX: Sint Maarten
