### PR TITLE
Fix yaml parsing error in countries.yaml, removing forbidden \t chars

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -97,7 +97,7 @@ AF:
   - アフガニスタン
   translations:
     en: Afghanistan
-    it: Afghanistan	
+    it: Afghanistan
     de: Afghanistan
     fr: Afganistán
     es:
@@ -2159,7 +2159,7 @@ DJ:
     it: Gibuti
     de: Dschibuti
     fr: Djibouti
-    es: Yibuti 
+    es: Yibuti
     ja: ジブチ
   national_destination_code_lengths:
   - 2
@@ -5188,7 +5188,7 @@ MD:
   - Moldavia
   - the Republic of Moldova
   - モルドバ共和国
-  translations:	  
+  translations:
     en: Moldova
     it: Moldavia
     de: Moldawie
@@ -6261,7 +6261,7 @@ NP:
   - Nepal
   - the Federal Democratic Republic of Nepal
   - ネパール
-  translations:	
+  translations:
     en: Nepal
     it: Nepal
     de: Népal
@@ -6829,7 +6829,7 @@ PS:
     it: Palestina
     de: Palästina
     fr: Palestina
-    es: Palestina 
+    es: Palestina
     ja: パレスチナ
   national_destination_code_lengths:
   - 2
@@ -6900,7 +6900,7 @@ PW:
   - パラオ
   translations:
     en: Palau
-    it: Palau 
+    it: Palau
     de: Palau
     fr: Palaos
     es: Palau


### PR DESCRIPTION
Validated with http://yaml-online-parser.appspot.com
