### PR TITLE
Useful #to_s method

### DIFF
--- a/lib/countries.rb
+++ b/lib/countries.rb
@@ -4,4 +4,7 @@ require 'iso3166'
 require 'countries/mongoid' if defined?(Mongoid)
 
 class Country < ISO3166::Country
+  def to_s
+    self.name
+  end
 end

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -69,6 +69,10 @@ class ISO3166::Country
     @data['eu_member'].nil? ? false : @data['eu_member']
   end
 
+  def to_s
+    @data['name']
+  end
+
   class << self
     def new(country_data)
       if country_data.is_a?(Hash) || Data.keys.include?(country_data.to_s.upcase)

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -203,6 +203,12 @@ describe ISO3166::Country do
 
         it { should == ISO3166::Country }
       end
+
+      describe 'to_s' do
+        it 'should return the country name' do
+          Country.new('GB').to_s.should == 'United Kingdom'
+        end
+      end
     end
   end
 
@@ -379,6 +385,12 @@ describe ISO3166::Country do
 
     it 'should return true for countries with eu_member flag set to true' do
       netherlands.in_eu?.should be_true
+    end
+  end
+
+  describe 'to_s' do
+    it 'should return the country name' do
+      ISO3166::Country.new('GB').to_s.should == 'United Kingdom'
     end
   end
 


### PR DESCRIPTION
Because `"United Kingdom"` is more useful than `"#<Country:0x007f8e138a2a48>"`.

Duplicated across classes because it's a monkey patch on `Kernel` and I thought a module or delegation was a bit overkill.
