### PR TITLE
Updated destination code and number lengths for Germany

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -2230,7 +2230,10 @@ DE:
   national_destination_code_lengths:
   - 2
   - 3
+  - 4
+  - 5
   national_number_lengths:
+  - 6
   - 7
   - 8
   - 9


### PR DESCRIPTION
I updated the national number lengths as noted in #109. I also updated the NDC lengths, the maximum length is 5. 
