### PR TITLE
Update county names in Croatia

### DIFF
--- a/lib/data/subdivisions/HR.yaml
+++ b/lib/data/subdivisions/HR.yaml
@@ -1,86 +1,106 @@
 ---
 ? "01"
 :
-  name: "Zagrebacka županija"
-  names: "Zagrebacka županija"
+  name: "Zagrebačka županija"
+  names:
+    - "Zagreb County"
 ? "02"
 :
   name: "Krapinsko-zagorska županija"
-  names: "Krapinsko-zagorska županija"
+  names:
+    - "Krapina-Zagorje"
 ? "03"
 :
-  name: "Sisacko-moslavacka županija"
-  names: "Sisacko-moslavacka županija"
+  name: "Sisačko-moslavačka županija"
+  names:
+    - "Sisak-Moslavina"
 ? "04"
 :
-  name: "Karlovacka županija"
-  names: "Karlovacka županija"
+  name: "Karlovačka županija"
+  names:
+    - "Karlovac"
 ? "05"
 :
   name: "Varaždinska županija"
-  names: "Varaždinska županija"
+  names:
+    - "Varaždin"
 ? "06"
 :
-  name: "Koprivnicko-križevacka županija"
-  names: "Koprivnicko-križevacka županija"
+  name: "Koprivničko-križevačka županija"
+  names:
+    - "Koprivnica-Križevci"
 ? "07"
 :
   name: "Bjelovarsko-bilogorska županija"
-  names: "Bjelovarsko-bilogorska županija"
-08:
+  names:
+    - "Bjelovar-Bilogora"
+? "08"
+:
   name: "Primorsko-goranska županija"
-  names: "Primorsko-goranska županija"
-09:
-  name: "Licko-senjska županija"
-  names: "Licko-senjska županija"
+  names:
+    - "Primorje-Gorski Kotar"
+? "09"
+:
+  name: "Ličko-senjska županija"
+  names:
+    - "Lika-Senj"
 ? "10"
 :
-  name: "Viroviticko-podravska županija"
-  names: "Viroviticko-podravska županija"
+  name: "Virovitičko-podravska županija"
+  names:
+    - "Virovitica-Podravina"
 ? "11"
 :
   name: "Požeško-slavonska županija"
-  names: "Požeško-slavonska županija"
+  names:
+    - "Požega-Slavonia"
 ? "12"
 :
   name: "Brodsko-posavska županija"
-  names: "Brodsko-posavska županija"
+  names:
+    - "Brod-Posavina"
 ? "13"
 :
   name: "Zadarska županija"
-  names: "Zadarska županija"
+  names:
+    - "Zadar"
 ? "14"
 :
-  name: "Osjecko-baranjska županija"
-  names: "Osjecko-baranjska županija"
+  name: "Osječko-baranjska županija"
+  names:
+    - "Osijek-Baranja"
 ? "15"
 :
   name: "Šibensko-kninska županija"
-  names: "Šibensko-kninska županija"
+  names:
+    - "Šibenik-Knin"
 ? "16"
 :
   name: "Vukovarsko-srijemska županija"
   names:
-    - Vukovar-Sirmium
+    - "Vukovar-Sirmium"
 ? "17"
 :
   name: "Splitsko-dalmatinska županija"
   names:
-    - Split-Dalmatia
+    - "Split-Dalmatia"
 ? "18"
 :
   name: "Istarska županija"
   names:
-    - Istria
+    - "Istria"
 ? "19"
 :
-  name: "Dubrovacko-neretvanska županija"
-  names: "Dubrovacko-neretvanska županija"
+  name: "Dubrovačko-neretvanska županija"
+  names:
+    - "Dubrovnik-Neretva"
 ? "20"
 :
-  name: "Medimurska županija"
-  names: "Medimurska županija"
+  name: "Međimurska županija"
+  names:
+    - "Međimurje"
 ? "21"
 :
   name: "Grad Zagreb"
-  names: "Grad Zagreb"
+  names:
+    - "City of Zagreb"


### PR DESCRIPTION
Changes:
- fixed local names to properly use letters "č" and "đ"
- updated English names
- consolidated numeric labels

Reference: http://en.wikipedia.org/wiki/Counties_of_Croatia
