### PR TITLE
Updated country name for Palestine

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -7304,7 +7304,7 @@ PS:
   ioc: PLE
   latitude: ''
   longitude: ''
-  name: Palestinian Territory, Occupied
+  name: Palestine, State of
   names:
   - Palestine
   - Palästina


### PR DESCRIPTION
2013-02-06 (Newsletter VI-14): Name of Palestine changed from "Occupied Palestinian Territory" to "State of Palestine".  See http://www.iso.org/iso/iso_3166-1_newsletter_vi-14_name_change_state_of_palestine.pdf
