### PR TITLE
Added the method #all_translated(locale) that returns a list of translated country names.

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -91,6 +91,11 @@ class ISO3166::Country
 
     alias :countries :all
 
+    def all_translated(locale='en')
+      translate = ->(country) { self.new(country[1]).translations[locale] }
+      list = self.all.map(&translate).compact.sort
+    end
+
     def search(query)
       country = self.new(query.to_s.upcase)
       (country && country.valid?) ? country : nil

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -158,6 +158,26 @@ describe ISO3166::Country do
     end
   end
 
+  describe 'all_translated' do
+    it 'should return an alphabetized list of all country names translated to the selected locale' do
+      countries = ISO3166::Country.all_translated('fr')
+      countries.should be_an(Array)
+      countries.first.should be_a(String)
+      countries.first.should eq('Afganistán')
+      # countries missing the desired locale will not be added to the list
+      # so all 250 countries may not be returned, 'fr' returns 247, for example
+      countries.should have(247).countries
+    end
+
+    it 'should return an alphabetized list of all country names in English if no locale is passed' do
+      countries = ISO3166::Country.all_translated
+      countries.should be_an(Array)
+      countries.first.should be_a(String)
+      countries.first.should eq('Afghanistan')
+      countries.should have(250).countries
+    end
+  end
+
   describe 'countries' do
     it 'should be the same as all' do
       ISO3166::Country.countries.should == ISO3166::Country.all


### PR DESCRIPTION
- The returned list is only an array of country name strings
- The returned list is alphabetized in the translated language
- Countries that are missing locales are dropped from the list

I saw someone requested a feature like this: https://github.com/hexorx/countries/issues/110

And someone asked a question on StackOverflow requesting this functionality: http://stackoverflow.com/questions/22366065/translate-array-of-countries-from-countries-gem-in-rails/22366129#22366129
