### PR TITLE
FR translations for CW and BQ countries

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -1220,6 +1220,7 @@ BQ:
   - ボネール、シント・ユースタティウスおよびサバ
   translations:
     en: Bonaire, Sint Eustatius and Saba
+    fr: Pays-Bas caribéens
     ru: Бонэйр, Синт-Эстатиус и Саба
     ja: ボネール、シント・ユースタティウスおよびサバ
   national_destination_code_lengths:
@@ -2116,6 +2117,7 @@ CW:
   - キュラソー島
   translations:
     en: Curaçao
+    fr: Curaçao
     ja: キュラソー島
     nl: Curaçao
     ru: Кюрасао


### PR DESCRIPTION
I noticed those two were missing during a test on my own code ; now the FR set is complete.

Thanks again for the awesome work on this gem.
