### PR TITLE
Update Japanese translation

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -9105,14 +9105,14 @@ TW:
   names:
   - Taiwan
   - Taiwán
-  - 台湾（台湾省/中華民国）
+  - 台湾
   translations:
     en: Taiwan
     it: Taiwan
     de: Taiwan
     fr: Taïwan
     es: Taiwán
-    ja: 台湾（台湾省/中華民国）
+    ja: 台湾
     nl: Taiwan
     ru: Тайвань
   national_destination_code_lengths:


### PR DESCRIPTION
"台湾" is a more correct translation than "台湾（台湾省/中華民国）".
ref. [wikipedia:台湾](http://ja.wikipedia.org/wiki/%E5%8F%B0%E6%B9%BE)
