### PR TITLE
adding NO- to the list of Norway counties. Based on the ISO 3166 description for Norway.

### DIFF
--- a/lib/data/subdivisions/NO.yaml
+++ b/lib/data/subdivisions/NO.yaml
@@ -1,84 +1,65 @@
 ---
-? "01"
-:
+NO-01:
   name: Østfold
   names: Østfold
-? "02"
-:
+NO-02:
   name: Akershus
   names: Akershus
-? "03"
-:
+NO-03:
   name: Oslo
   names: Oslo
-? "04"
-:
+NO-04:
   name: Hedmark
   names: Hedmark
-? "05"
-:
+NO-05:
   name: Oppland
   names: Oppland
-? "06"
-:
+NO-06:
   name: Buskerud
   names: Buskerud
-? "07"
-:
+NO-07:
   name: Vestfold
   names: Vestfold
-08:
+NO-08:
   name: Telemark
   names: Telemark
-09:
+NO-09:
   name: Aust-Agder
   names: Aust-Agder
-? "10"
-:
+NO-10:
   name: Vest-Agder
   names: Vest-Agder
-? "11"
-:
+NO-11:
   name: Rogaland
   names: Rogaland
-? "12"
-:
+NO-12:
   name: Hordaland
   names: Hordaland
-? "14"
-:
+NO-14:
   name: "Sogn og Fjordane"
   names: "Sogn og Fjordane"
-? "15"
-:
+NO-15:
   name: "Møre og Romsdal"
   names: "Møre og Romsdal"
-? "16"
-:
+NO-16:
   name: Sør-Trøndelag
   names: Sør-Trøndelag
-? "17"
-:
+NO-17:
   name: Nord-Trøndelag
   names: Nord-Trøndelag
-? "18"
-:
+NO-18:
   name: Nordland
   names: Nordland
-? "19"
-:
+NO-19:
   name: Troms
   names: Troms
-? "20"
-:
+NO-20:
   name: Finnmark
   names:
     - Finnmarku
-? "21"
-:
+NO-21:
   name: "Svalbard (Arctic Region) (See also country code SJ)"
   names: "Svalbard (Arctic Region) (See also country code SJ)"
-? "22"
-:
+NO-22:
   name: "Jan Mayen (Arctic Region) (See also country code SJ)"
   names: "Jan Mayen (Arctic Region) (See also country code SJ)"


### PR DESCRIPTION
As for the documentation, the ISO-3166 code for Norway's counties must have the NO- code attached to it.

I just added this to the Norway codes.
