### PR TITLE
Add additional names for Russia & Ukraine

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -7643,6 +7643,7 @@ RU:
   - Rusia
   - ロシア連邦
   - Rusland
+  - Россия
   translations:
     en: Russia
     ru: Российская Федерация
@@ -9191,6 +9192,8 @@ UA:
   - Ucrania
   - ウクライナ
   - Oekraïne
+  - Украина
+  - Україна
   translations:
     en: Ukraine
     it: Ucraina


### PR DESCRIPTION
Added other known names for Russia and Ukraine.
- "Россия" (Russia) is more commonly used term.
- "Украина" is Ukraine in Russian.
- "Україна" is Ukraine in Ukrainian.

We need to add "Россия" into `names` because it is used more often than more official "Российская Федерация". It appears in most of the service API results and having it in the `names` would make our code much simpler.
