### PR TITLE
Latvia's currency is now the Euro

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -5420,7 +5420,7 @@ LV:
   alpha2: LV
   alpha3: LVA
   country_code: '371'
-  currency: LVL
+  currency: EUR
   international_prefix: '00'
   ioc: LAT
   latitude: 57 00 N


### PR DESCRIPTION
https://www.ecb.europa.eu/euro/changeover/latvia/html/index.en.html
