### PR TITLE
Add custom countries to translation lists

### DIFF
--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -46,7 +46,15 @@ module ISO3166
     end
 
     def translations(locale = 'en')
-      I18nData.countries(locale.upcase)
+      i18n_data_countries = I18nData.countries(locale.upcase)
+
+      custom_countries = (ISO3166::Data.codes - i18n_data_countries.keys).map do |code|
+        country = ISO3166::Country[code]
+        translation = country.translations[locale] || country.name
+        [code, translation]
+      end.to_h
+
+      i18n_data_countries.merge(custom_countries)
     end
 
     def search(query)

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -335,6 +335,26 @@ describe ISO3166::Country do
       expect(countries.first).to eq('Aruba')
       expect(countries.size).to eq(NUM_OF_COUNTRIES)
     end
+
+    context 'with custom countries' do
+      before do
+        ISO3166::Data.register(
+          alpha2: 'XX',
+          name: 'Custom Country',
+          translations: { 'en' => 'Custom Country' }
+        )
+      end
+
+      it 'should include custom registered countries' do
+        custom_country = ISO3166::Country.find_by_alpha2('XX')[1]
+        countries = ISO3166::Country.all_translated
+        expect(countries).to include(custom_country['name'])
+      end
+
+      after do
+        ISO3166::Data.unregister('XX')
+      end
+    end
   end
 
   describe 'all_names_with_codes' do


### PR DESCRIPTION
This is code by @wmnnd from issue #550.

When adding a custom country with `ISO3166::Data.register`, it does not end up in the translation list. This PR merges those custom registered countries into the translations.