### PR TITLE
Fix ISO3166::Country respond_to_missing?

### DIFF
--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -70,7 +70,7 @@ module ISO3166
     def respond_to_missing?(method_name, include_private = false)
       matches = method_name.to_s.match(FIND_BY_REGEX)
       if matches && matches[3]
-        matches[3].all? { |a| instance_methods.include?(a.to_sym) }
+        instance_methods.include?(matches[3].to_sym)
       else
         super
       end

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -780,6 +780,45 @@ describe ISO3166::Country do
     end
   end
 
+  describe 'finder methods respond_to_missing?' do
+    subject { ISO3166::Country.respond_to?(method_name) }
+    describe 'find_all_by' do
+      context 'find by a valid Country attribute' do
+        let(:method_name) { :find_all_by_currency }
+        it { is_expected.to be true }
+      end
+
+      context 'find by an invalid attribute' do
+        let(:method_name) { :find_all_by_invalid }
+        it { is_expected.to be false }
+      end
+    end
+
+    describe 'hash finder methods' do
+      context 'find by a valid Country attribute' do
+        let(:method_name) { :find_by_name }
+        it { is_expected.to be true }
+      end
+
+      context 'find by an invalid attribute' do
+        let(:method_name) { :find_by_invalid }
+        it { is_expected.to be false }
+      end
+    end
+
+    describe 'country finder methods' do
+      context 'find country by a valid Country attribute' do
+        let(:method_name) { :find_country_by_alpha3 }
+        it { is_expected.to be true }
+      end
+
+      context 'find by an invalid attribute' do
+        let(:method_name) { :find_country_by_invalid }
+        it { is_expected.to be false }
+      end
+    end
+  end
+
   describe 'names in Data' do
     it 'should be unique (to allow .find_by_name work properly)' do
       names = ISO3166::Data.cache.map do |_k, v|


### PR DESCRIPTION
Fix `ISO3166::Country.respond_to_missing?` for finder methods like `find_country_by_name`

## Reason

Using rspec-mocks to stub methods on `ISO3166::Country` is broken. As an example, the following snippet raises an error:

```ruby
let(:found_country) { double }
before
  allow(ISO3166::Country).to receive(:find_country_by_alpha2)
    .and_return(found_country)
end
```

Raises:

```
NoMethodError:
  undefined method `all?' for "alpha2":String
```