### PR TITLE
Make cache thread safe

### DIFF
--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -5,6 +5,7 @@ module ISO3166
     @@cache_dir = [File.dirname(__FILE__), 'cache']
     @@cache = {}
     @@registered_data = {}
+    @@mutex = Mutex.new
 
     def initialize(alpha2)
       @alpha2 = alpha2.to_s.upcase
@@ -61,10 +62,12 @@ module ISO3166
 
       def load_data!
         return @@cache unless load_required?
-        @@cache = load_cache %w(countries.json)
-        @@_country_codes = @@cache.keys
-        @@cache = @@cache.merge(@@registered_data)
-        @@cache
+        synchronized do
+          @@cache = load_cache %w(countries.json)
+          @@_country_codes = @@cache.keys
+          @@cache = @@cache.merge(@@registered_data)
+          @@cache
+        end
       end
 
       def sync_translations!
@@ -81,8 +84,23 @@ module ISO3166
 
       private
 
+      def synchronized(&block)
+        if use_mutex?
+          @@mutex.synchronize(&block)
+        else
+          block.call
+        end
+      end
+
+      def use_mutex?
+        # Stubbed in testing
+        true
+      end
+
       def load_required?
-        @@cache.empty?
+        synchronized do
+          @@cache.empty?
+        end
       end
 
       def loaded_codes
@@ -115,21 +133,25 @@ module ISO3166
       end
 
       def load_translations(locale)
-        locale_names = load_cache(['locales', "#{locale}.json"])
-        internal_codes.each do |alpha2|
-          @@cache[alpha2]['translations'] ||= Translations.new
-          @@cache[alpha2]['translations'][locale] = locale_names[alpha2].freeze
-          @@cache[alpha2]['translated_names'] = @@cache[alpha2]['translations'].values.freeze
+        synchronized do
+          locale_names = load_cache(['locales', "#{locale}.json"])
+          internal_codes.each do |alpha2|
+            @@cache[alpha2]['translations'] ||= Translations.new
+            @@cache[alpha2]['translations'][locale] = locale_names[alpha2].freeze
+            @@cache[alpha2]['translated_names'] = @@cache[alpha2]['translations'].values.freeze
+          end
+          ISO3166.configuration.loaded_locales << locale
         end
-        ISO3166.configuration.loaded_locales << locale
       end
 
       def unload_translations(locale)
-        internal_codes.each do |alpha2|
-          @@cache[alpha2]['translations'].delete(locale)
-          @@cache[alpha2]['translated_names'] = @@cache[alpha2]['translations'].values.freeze
+        synchronized do
+          internal_codes.each do |alpha2|
+            @@cache[alpha2]['translations'].delete(locale)
+            @@cache[alpha2]['translated_names'] = @@cache[alpha2]['translations'].values.freeze
+          end
+          ISO3166.configuration.loaded_locales.delete(locale)
         end
-        ISO3166.configuration.loaded_locales.delete(locale)
       end
 
       def load_cache(file_array)

--- a/spec/thread_safety_spec.rb
+++ b/spec/thread_safety_spec.rb
@@ -1,0 +1,46 @@
+describe 'Accessing ISO3166::Country instances data in multiple threads' do
+  before do
+    if Thread.respond_to?(:report_on_exception)
+      @report_on_exception_value = Thread.report_on_exception
+      Thread.report_on_exception = false
+    end
+
+    ISO3166::Data.reset
+  end
+
+  def create_countries_threaded
+    nthreads = 100
+    threads = []
+
+    alpha2_codes = ['us', 'es', 'nl', 'ca', 'de', 'fr', 'mx', 'ru', 'ch', 'jp']
+
+    nthreads.times do
+      threads << Thread.new do
+        alpha2_codes.each do |a2|
+          country = ISO3166::Country[a2]
+          # This will fail if data['translations'] has been
+          # left nil due to a race condition
+          country.translation
+        end
+      end
+    end
+    threads.map(&:join)
+  end
+
+  it "doesn't raise any exceptions when using a mutex" do
+    expect { create_countries_threaded }.to_not raise_error
+  end
+
+  it "raises NoMethodError when not using a mutex" do
+    allow(ISO3166::Data).to receive(:use_mutex?).and_return(false)
+
+    expect { create_countries_threaded }.to raise_error(NoMethodError)
+  end
+
+  after do
+    if Thread.respond_to?(:report_on_exception)
+      Thread.report_on_exception = @report_on_exception_value
+    end
+  end
+end
+


### PR DESCRIPTION
This PR fixes issue #499 by use of a Mutex in the `Data` class

We at @factorialco use (multi-thread but not multi-worker) Puma in production and have been hit by it just recently

I've added a failing test that checks that a race condition happens when the mutex isn't present and doesn't when it is present. I've run this 1000 times using a script and haven't got a single failure.

The test is fairly rough and it's not unitary by any means, but I think it's clearly an improvement