### PR TITLE
Set the code when creating subdivisions

### DIFF
--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -103,7 +103,8 @@ module ISO3166
 
     def create_subdivisions(subdivision_data)
       subdivision_data.each_with_object({}) do |(k, v), hash|
-        hash[k] = Subdivision.new(v)
+        data = v.merge('code' => k.to_s)
+        hash[k] = Subdivision.new(data)
       end
     end
 

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -248,6 +248,10 @@ describe ISO3166::Country do
       expect(virginia.name).to eq('Virginia')
     end
 
+    it 'should have a code' do
+      expect(virginia.code).to eq('VA')
+    end
+
     it 'should behave like a hash' do
       expect(virginia['name']).to eq('Virginia')
     end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -116,8 +116,8 @@ describe ISO3166::Data do
       expect(subject.name).to eq 'NEW Taiwan'
       expect(subject.translations).to eq('en' => 'NEW Taiwan',
                                          'de' => 'NEW Taiwan')
-      expect(subject.subdivisions).to eq('CHA' => ISO3166::Subdivision.new({name: 'New Changhua'}),
-                                         'CYI' => ISO3166::Subdivision.new({name: 'New Municipality'}))
+      expect(subject.subdivisions).to eq('CHA' => ISO3166::Subdivision.new({name: 'New Changhua', code: 'CHA'}),
+                                         'CYI' => ISO3166::Subdivision.new({name: 'New Municipality', code: 'CYI'}))
     end
   end
 
@@ -143,8 +143,8 @@ describe ISO3166::Data do
       data = ISO3166::Data.new('LOL').call
       expect(data['name']).to eq 'Happy Country'
       expect(subject.name).to eq 'Happy Country'
-      expect(subject.subdivisions).to eq('LOL1' => ISO3166::Subdivision.new({name: 'Happy sub1'}),
-                                         'LOL2' => ISO3166::Subdivision.new({name: 'Happy sub2'}))
+      expect(subject.subdivisions).to eq('LOL1' => ISO3166::Subdivision.new({name: 'Happy sub1', code: 'LOL1'}),
+                                         'LOL2' => ISO3166::Subdivision.new({name: 'Happy sub2', code: 'LOL2'}))
     end
 
     it 'detect a stale cache' do


### PR DESCRIPTION
The subdivision struct has a `code` parameter, but it's never set because the data doesn't actually contain the subdivision codes (they're used as the keys). 

This is a bit of a pain partly because it was just confusing, but mostly because it means that given a `Subdivision` object it's nearly impossible to actually get the code.

This simply sets the `code` parameter when creating the subdivisions, adds a test and updates other tests as appropriate.