### PR TITLE
Swedish translation correction: RU = "Ryssland"

### DIFF
--- a/lib/countries/data/translation_corrections.yaml
+++ b/lib/countries/data/translation_corrections.yaml
@@ -34,5 +34,6 @@ he:
   VI: "איי הבתולה (ארה)"
 sv:
   GB: "Storbritannien"
+  RU: "Ryssland"
 pt:
   CZ: 'República Checa'


### PR DESCRIPTION
Currently translated as "Ryska federationen" which is as though the English translation had been "Russian Federation" – not what you'd normally call it.

Since the GB = "Storbritannien" correction was made without a corresponding correction in https://salsa.debian.org/iso-codes-team/iso-codes/-/blob/main/iso_3166-1/sv.po (or https://hosted.weblate.org/translate/iso-codes/iso-3166-1/sv) I assumed this would be fine also. Though I may try to raise an issue there too.

EDIT: Poked around more and realised the English translation *is* "Russian Federation" :) Perhaps it would be a good idea to change that one to "Russia"? I'll leave that for a separate PR, though.