### PR TITLE
Updating Norway subdivision codes to match late 2020 ISO change 

### DIFF
--- a/lib/countries/data/subdivisions/NO.yaml
+++ b/lib/countries/data/subdivisions/NO.yaml
@@ -1,28 +1,3 @@
----
-NO-01:
-  unofficial_names: Østfold
-  translations:
-    en: Østfold
-  geo:
-    latitude: 59.25582859999999
-    longitude: 11.3279007
-    min_latitude: 58.8768946
-    min_longitude: 10.5764046
-    max_latitude: 59.79051459999999
-    max_longitude: 11.9460045
-  name: Østfold
-NO-02:
-  unofficial_names: Akershus
-  translations:
-    en: Akershus
-  geo:
-    latitude: 60.00002019999999
-    longitude: 11.3690301
-    min_latitude: 59.4718821
-    min_longitude: 10.3290796
-    max_latitude: 60.59664780000001
-    max_longitude: 11.9260507
-  name: Akershus
 NO-03:
   unofficial_names: Oslo
   translations:
@@ -35,90 +10,6 @@ NO-03:
     max_latitude: 59.978035
     max_longitude: 10.9476642
   name: Oslo
-NO-04:
-  unofficial_names: Hedmark
-  translations:
-    en: Hedmark
-  geo:
-    latitude: 61.3967311
-    longitude: 11.5627369
-    min_latitude: 59.84135440000001
-    min_longitude: 9.5838267
-    max_latitude: 62.6969236
-    max_longitude: 12.8708487
-  name: Hedmark
-NO-05:
-  unofficial_names: Oppland
-  translations:
-    en: Oppland
-  geo:
-    latitude: 61.5422752
-    longitude: 9.716631399999999
-    min_latitude: 60.13160989999999
-    min_longitude: 7.3425305
-    max_latitude: 62.37840250000001
-    max_longitude: 11.1327999
-  name: Oppland
-NO-06:
-  unofficial_names: Buskerud
-  translations:
-    en: Buskerud
-  geo:
-    latitude: 60.48460249999999
-    longitude: 8.698376399999999
-    min_latitude: 59.4078708
-    min_longitude: 7.438842299999999
-    max_latitude: 61.0917205
-    max_longitude: 10.6192606
-  name: Buskerud
-NO-07:
-  unofficial_names: Vestfold
-  translations:
-    en: Vestfold
-  geo:
-    latitude: 59.17078619999999
-    longitude: 10.1144355
-    min_latitude: 58.8402834
-    min_longitude: 9.7553356
-    max_latitude: 59.6915912
-    max_longitude: 10.6001915
-  name: Vestfold
-NO-08:
-  unofficial_names: Telemark
-  translations:
-    en: Telemark
-  geo:
-    latitude: 59.39139849999999
-    longitude: 8.321121
-    min_latitude: 58.76740489999999
-    min_longitude: 7.0962874
-    max_latitude: 60.1882718
-    max_longitude: 9.895088099999999
-  name: Telemark
-NO-09:
-  unofficial_names: Aust-Agder
-  translations:
-    en: Aust-Agder
-  geo:
-    latitude: 58.66703039999999
-    longitude: 8.0844752
-    min_latitude: 58.1050135
-    min_longitude: 6.8245331
-    max_latitude: 59.6704093
-    max_longitude: 9.3693846
-  name: Aust-Agder
-NO-10:
-  unofficial_names: Vest-Agder
-  translations:
-    en: Vest-Agder
-  geo:
-    latitude: 58.368605
-    longitude: 6.901961600000001
-    min_latitude: 57.95849709999999
-    min_longitude: 6.3765277
-    max_latitude: 59.18884579999999
-    max_longitude: 8.2098324
-  name: Vest-Agder
 NO-11:
   unofficial_names: Rogaland
   translations:
@@ -131,30 +22,6 @@ NO-11:
     max_latitude: 59.84433379999999
     max_longitude: 7.2119667
   name: Rogaland
-NO-12:
-  unofficial_names: Hordaland
-  translations:
-    en: Hordaland
-  geo:
-    latitude: 60.2733674
-    longitude: 5.7220194
-    min_latitude: 59.4759811
-    min_longitude: 4.6334781
-    max_latitude: 61.0352379
-    max_longitude: 7.732114699999999
-  name: Hordaland
-NO-14:
-  unofficial_names: Sogn og Fjordane
-  translations:
-    en: Sogn og Fjordane
-  geo:
-    latitude: 61.5539435
-    longitude: 6.3325879
-    min_latitude: 60.67554759999999
-    min_longitude: 4.5000011
-    max_latitude: 62.2168708
-    max_longitude: 8.3220528
-  name: Sogn og Fjordane
 NO-15:
   unofficial_names: Møre og Romsdal
   translations:
@@ -167,30 +34,6 @@ NO-15:
     max_latitude: 63.5377568
     max_longitude: 9.5842118
   name: Møre og Romsdal
-NO-16:
-  unofficial_names: Sør-Trøndelag
-  translations:
-    en: Sør-Trøndelag
-  geo:
-    latitude: 63.0136823
-    longitude: 10.3487135
-    min_latitude: 62.2557267
-    min_longitude: 8.233780099999999
-    max_latitude: 64.4653999
-    max_longitude: 12.2467012
-  name: Sør-Trøndelag
-NO-17:
-  unofficial_names: Nord-Trøndelag
-  translations:
-    en: Nord-Trøndelag
-  geo:
-    latitude: 64.4370792
-    longitude: 11.7462949
-    min_latitude: 63.1806873
-    min_longitude: 10.1335962
-    max_latitude: 65.39440379999999
-    max_longitude: 14.3259858
-  name: Nord-Trøndelag
 NO-18:
   unofficial_names: Nordland
   translations:
@@ -198,171 +41,112 @@ NO-18:
   geo:
     latitude: 67.69167019999999
     longitude: 12.7019476
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Nordland
-NO-19:
-  unofficial_names: Troms
-  translations:
-    en: Troms
-  geo:
-    latitude: 69.81782419999999
-    longitude: 18.7819365
-    min_latitude: 68.3560138
-    min_longitude: 15.5925417
-    max_latitude: 70.31976139999999
-    max_longitude: 22.8944657
-  name: Troms
-NO-20:
-  unofficial_names:
-  - Finnmarku
-  translations:
-    en: Finnmark
-  geo:
-    latitude: 70.4830388
-    longitude: 26.0135108
-    min_latitude: 68.55459180000001
-    min_longitude: 21.173939
-    max_latitude: 71.1854762
-    max_longitude: 31.1682684
-  name: Finnmark
 NO-21:
-  unofficial_names: Svalbard (Arctic Region) (See also country code SJ)
+  unofficial_names: Svalbard (Arctic Region)
   translations:
-    en: Svalbard (Arctic Region) (See also country code SJ)
+    en: Svalbard (Arctic Region)
   geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Svalbard (Arctic Region) (See also country code SJ)
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Svalbard (Arctic Region)
 NO-22:
-  unofficial_names: Jan Mayen (Arctic Region) (See also country code SJ)
+  unofficial_names: Jan Mayen (Arctic Region)
   translations:
-    en: Jan Mayen (Arctic Region) (See also country code SJ)
+    en: Jan Mayen
   geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Jan Mayen (Arctic Region) (See also country code SJ)
-'01':
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Jan Mayen (Arctic Region)
+NO-30:
   translations:
-    af: Østfold
-    ar: أوستفولد
-    be: Эстфал
-    bg: Йостфол
-    bn: ওস্টফোল্ড
-    ca: Østfold
-    cs: Østfold
-    da: Østfold
-    de: Østfold
-    el: Όστφολντ
-    en: Østfold
-    es: Østfold
-    et: Østfold
-    eu: Østfold
-    fa: اوستفولد
-    fi: Østfoldin lääni
-    fr: Comté d’Østfold
-    gu: ઓસ્ટફોલ્ડ
-    he: אסטפולד
-    hi: ओस्टफ़ोल्ड
-    hr: Østfold
-    hu: Østfold megye
-    hy: Էստֆոլդ
-    id: Østfold
-    is: Austfold
-    it: Østfold
-    ja: エストフォル県
-    ka: ესტფოლდი
-    kn: ಓಸ್ಟ್ಫೋಲ್ಡ್
-    ko: 외스트폴 주
-    lt: Estfoldas
-    mr: ओस्टफॉल्ड
-    ms: Ostfold
-    nb: Østfold
-    nl: Østfold
-    pl: Østfold
-    pt: Østfold
-    ro: Østfold
-    ru: Эстфолл
-    si: ඔස්ට්ෆෝල්ඩ්
-    sk: Østfold
-    sl: Østfold
-    sr: Естфолд
-    sv: Østfold fylke
-    sw: Østfold
-    ta: ஒஸ்டபோல்டு
-    te: ఓస్ట్‌ఫోల్డ్
-    th: แอสต์โฟลด์
-    tr: Østfold
-    uk: Естфол
-    ur: اوستفول
-    vi: Østfold
-    zh: 东福尔郡
-'02':
+    en: Viken
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Viken
+NO-34:
   translations:
-    af: Akershus
-    ar: آكرشوس
-    be: Акерсхус
-    bg: Акешхус
-    bn: একেরশাস
-    ca: Akershus
-    cs: Akershus
-    da: Akershus
-    de: Akershus
-    el: Ακέρσους
-    en: Akershus
-    es: Akershus
-    et: Akershus
-    eu: Akershus
-    fa: آکرشوس
-    fi: Akershusin lääni
-    fr: Comté d’Akershus
-    gu: અકર્સસ
-    he: אקרסהוס
-    hi: अकर्शस
-    hr: Akershus
-    hu: Akershus megye
-    hy: Ակերսհուս
-    id: Akershus
-    is: Akurshús
-    it: Akershus
-    ja: アーケシュフース県
-    ka: აკერსხუსი
-    kn: ಅಕರ್ಶಸ್
-    ko: 아케르스후스 주
-    lt: Akershusas
-    lv: Ākešhusa
-    mr: अकर्सस
-    ms: Akershus
-    nb: Akershus
-    ne: एकर्सहस
-    nl: Akershus
-    pl: Akershus
-    pt: Akershus
-    ro: Akershus
-    ru: Акерсхус
-    si: අකෙර්ෂුස්
-    sk: Akershus
-    sl: Akershus
-    sr: Акерсхус
-    sv: Akershus fylke
-    sw: Akershus
-    ta: அகிற்ஸ்ஸ்
-    te: ఆకేర్షస
-    th: อาเคอร์ชูส
-    tr: Akershus
-    uk: Акерсгус
-    ur: آکیشوس
-    vi: Akershus
+    en: Innlandet
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Innlandet
+NO-38:
+  translations:
+    en: Vestfold og Telemark
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Vestfold og Telemark
+NO-42:
+  translations:
+    en: Agder
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Agder
+NO-46:
+  translations:
+    en: Vestland
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Vestland
+NO-50:
+  translations:
+    en: Trøndelag
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Trøndelag
+NO-54:
+  translations:
+    en: Troms og Finnmark fylke
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Troms og Finnmark
 '03':
   translations:
     af: Oslo
@@ -427,327 +211,118 @@ NO-22:
     uk: Осло
     ur: اوسلو
     vi: Oslo
-'04':
+  geo:
+    latitude: 59.9138688
+    longitude: 10.7522454
+    min_latitude: 59.8096749
+    min_longitude: 10.6225688
+    max_latitude: 59.978035
+    max_longitude: 10.9476642
+  name: Oslo
+'11':
+  unofficial_names: Rogaland
   translations:
-    af: Hedmark
-    ar: هيدمارك
-    be: Хедмарк
-    bg: Хедмарк
-    bn: হেডমার্ক
-    ca: Hedmark
-    cs: Hedmark
-    da: Hedmark
-    de: Hedmark
-    el: Χέντμαρκ
-    en: Hedmark
-    es: Hedmark
-    et: Hedmark
-    eu: Hedmark
-    fa: هدمارک
-    fi: Hedmarkin lääni
-    fr: comté de Hedmark
-    gu: હેડેમાર્ક
-    hi: हेडमार्क
-    hr: Hedmark
-    hu: Hedmark megye
-    hy: Հեդմարկ
-    id: Hedmark
-    is: Heiðmörk
-    it: Hedmark
-    ja: ヘードマルク県
-    ka: ხედმარკი
-    kn: ಹೆಡ್ಮಾರ್ಕ್
-    ko: 헤드마르크 주
-    lt: Hedmarkas
-    mr: हेडमार्क
-    ms: Hedmark
-    nb: Hedmark
-    nl: Hedmark
-    pl: Hedmark
-    pt: Hedmark
-    ro: Hedmark
-    ru: Хедмарк
-    si: හෙඩ්මාර්ක්
-    sk: Hedmark
-    sl: Hedmark
-    sr: Хедмарк
-    sv: Hedmark fylke
-    sw: Hedmark
-    ta: ஹெட்மார்க்
-    te: హెడ్మార్క్
-    th: เฮ็ดมาร์ค
-    tr: Hedmark
-    uk: Гедмарк
-    ur: ہیڈمارک
-    vi: Hedmark
-'05':
+    ar: روغالاند
+    be: Ругалан
+    bg: Ругалан
+    ca: Rogaland
+    cs: Rogaland
+    da: Rogaland
+    de: Rogaland
+    en: Rogaland
+    es: Rogaland
+    et: Rogaland
+    eu: Rogaland
+    fa: روگالاند
+    fi: Rogalandin lääni
+    fr: comté de Rogaland
+    he: רוגלנד
+    hr: Rogaland
+    hu: Rogaland megye
+    hy: Ռուգլան
+    id: Rogaland
+    is: Rogaland
+    it: Rogaland
+    ja: ローガラン県
+    ka: რუგალანი
+    ko: 로갈란 주
+    lt: Rugalandas
+    lv: Rūgalanne
+    nb: Rogaland
+    nl: Rogaland
+    pl: Rogaland
+    pt: Rogaland
+    ro: Rogaland
+    ru: Ругаланн
+    sk: Rogaland
+    sl: Rogaland
+    sr: Рогаланд
+    sv: Rogaland fylke
+    sw: Rogaland
+    tr: Rogaland
+    uk: Руґалан
+    ur: روگالان
+    vi: Rogaland
+  geo:
+    latitude: 59.1489544
+    longitude: 6.0143431
+    min_latitude: 58.2776276
+    min_longitude: 4.844005999999999
+    max_latitude: 59.84433379999999
+    max_longitude: 7.2119667
+  name: Rogaland
+'15':
+  unofficial_names: Møre og Romsdal
   translations:
-    af: Oppland
-    ar: أوبلاند
-    be: Оплан
-    bg: Оплан
-    bn: অপল্যান্ড
-    ca: Oppland
-    cs: Oppland
-    da: Oppland
-    de: Oppland
-    el: Όπλαντ
-    en: Oppland
-    es: Oppland
-    et: Oppland
-    eu: Oppland
-    fa: اوپلاند (نروژ)
-    fi: Opplandin lääni
-    fr: comté d’Oppland
-    gu: ઓપ્પલેન્ડ
-    hi: ओपलैंड
-    hr: Oppland
-    hu: Oppland megye
-    hy: Օպլանդ
-    id: Oppland
-    is: Upplönd
-    it: Oppland
-    ja: オップラン県
-    ka: ოპლანი
-    kn: ಆಪ್ಲಾಂಡ್
-    ko: 오플란 주
-    lt: Oplandas
-    lv: Oplanne
-    mr: ऑप्पलँड
-    ms: Oppland
-    nb: Oppland
-    nl: Oppland
-    pl: Oppland
-    pt: Oppland
-    ro: Oppland
-    ru: Оппланн
-    si: ඔප්ලන්ඩ්
-    sk: Oppland
-    sl: Oppland
-    sr: Опланд
-    sv: Oppland fylke
-    sw: Oppland
-    ta: ஒப்பிலான்ட்
-    te: ఆప్లాండ్
-    th: เทศบาลเมืองโคการ์
-    tr: Oppland
-    uk: Опплан
-    ur: اوپلان
-    vi: Oppland
-'06':
-  translations:
-    af: Buskerud
-    ar: بوسكرود
-    be: Бускеруд
-    bg: Бюскерю
-    bn: বুস্কেরুদ
-    ca: Buskerud
-    cs: Buskerud
-    da: Buskerud
-    de: Buskerud
-    el: Μπούσκερουντ
-    en: Buskerud
-    es: Buskerud
-    et: Buskerud
-    eu: Buskerud
-    fa: بوسکرود
-    fi: Buskerudin lääni
-    fr: Comté de Buskerud
-    gu: બુસકેરુડ
-    hi: बस्केरूद
-    hr: Buskerud
-    hu: Buskerud megye
-    hy: Բուսկերուդ
-    id: Buskerud
-    is: Buskerud
-    it: Buskerud
-    ja: ブスケルー県
-    ka: ბუსკერუდი
-    kn: ಬಸ್ಕ್ರೋಡ್
-    ko: 부스케루 주
-    lt: Biuskeriudas
-    lv: Buskeruda
-    mr: बस्केरुड
-    ms: Buskerud
-    nb: Buskerud
-    nl: Buskerud
-    pl: Buskerud
-    pt: Buskerud
-    ro: Buskerud
-    ru: Бускеруд
-    si: බස්කෙරුඩ්
-    sk: Buskerud
-    sl: Buskerud
-    sr: Бускеруд
-    sv: Buskerud fylke
-    sw: Buskerud
-    ta: புஸ்கிருத்
-    te: బుస్కెరుడ్
-    th: เทศมณฑลบุสเครุด
-    tr: Buskerud
-    uk: Бускерюд
-    ur: بوسکرود
-    vi: Buskerud
-'07':
-  translations:
-    af: Vestfold
-    ar: فستفولد
-    be: Вестфал
-    bg: Вестфол
-    bn: ভেস্টফোল্ড
-    ca: Vestfold
-    cs: Vestfold
-    da: Vestfold
-    de: Vestfold
-    el: Βέστφολντ
-    en: Vestfold
-    es: Vestfold
-    et: Vestfold
-    eu: Vestfold
-    fa: وستفولد
-    fi: Vestfoldin lääni
-    fr: comté de Vestfold
-    gu: વેસ્ટફોલ્ડ
-    he: וסטפולד
-    hi: वेस्टफ़ोल्ड
-    hr: Vestfold
-    hu: Vestfold megye
-    id: Vestfold
-    is: Vestfold
-    it: Vestfold
-    ja: ヴェストフォル県
-    ka: ვესტფოლდი
-    kn: ವೆಸ್ಟ್ಫೋಲ್ಡ್
-    ko: 베스트폴 주
-    lt: Vestfoldas
-    mr: वेस्टफॉल्ड
-    ms: Vestfold
-    nb: Vestfold
-    nl: Vestfold
-    pl: Vestfold
-    pt: Vestfold
-    ro: Vestfold
-    ru: Вестфолл
-    si: වෙස්ට්ෆෝල්ඩ්
-    sk: Vestfold
-    sl: Vestfold
-    sr: Вестфолд
-    sv: Vestfold fylke
-    ta: வெஸ்டபோல்டு
-    te: వెస్ట్‌ఫోల్డ్
-    th: เทศมณฑลเวสต์ฟอลด์
-    tr: Vestfold
-    uk: Вестфол
-    ur: ویستفول
-    vi: Vestfold
-'10':
-  translations:
-    af: Vest-Agder
-    ar: فست أغدر
-    be: Вест-Агдэр
-    bg: Вест-Агдер
-    bn: ভেস্ত আগদের
-    ca: Vest-Agder
-    cs: Vest-Agder
-    da: Vest-Agder
-    de: Vest-Agder
-    el: Βεστ-Άγκντερ
-    en: Vest-Agder
-    es: Vest-Agder
-    et: Vest-Agder
-    eu: Vest-Agder
-    fa: وست آدر
-    fi: Länsi-Agderin lääni
-    fr: Comté de Vest-Agder
-    gu: વેસ્ટ-એડર
-    hi: वेस्ट-एग्डर
-    hr: Vest-Agder
-    hu: Vest-Agder megye
-    id: Vest-Agder
-    is: Vestur-Agðir
-    it: Vest-Agder
-    ja: ヴェスト・アグデル県
-    ka: ვესტ-აგდერი
-    kn: ವೆಸ್ಟ್-ಆಗ್ಡರ್
-    ko: 베스트아그데르 주
-    lt: Vakarų Agderis
-    mr: वेस्ट-एजडर
-    ms: Vest-Agder
-    nb: Vest-Agder
-    nl: Vest-Agder
-    pl: Vest-Agder
-    pt: Vest-Agder
-    ro: Vest-Agder
-    ru: Вест-Агдер
-    si: වෙස්ට්-අග්ඩර්
-    sk: Vest-Agder
-    sl: Vest-Agder
-    sr: Западни Агдер
-    sv: Vest-Agder fylke
-    ta: வேஸ்ட் - அஃடெர்
-    te: వెస్ట్‌-ఆగ్డర్
-    th: เวส-แอดเดอ
-    tr: Vest-Agder
-    uk: Вест-Аґдер
-    ur: ویست-آگدیر
-    vi: Vest-Agder
-'12':
-  translations:
-    af: Hordaland
-    ar: هوردالان
-    be: Хордалан
-    bg: Хордалан
-    bn: হর্ডাল্যান্ড
-    ca: Hordaland
-    cs: Hordaland
-    da: Hordaland
-    de: Hordaland
-    el: Χόρνταλαντ
-    en: Hordaland
-    es: Hordaland
-    et: Hordaland
-    eu: Hordaland
-    fa: هوردالاند
-    fi: Hordalandin lääni
-    fr: comté de Hordaland
-    gu: હોર્ડલેન્ડ
-    he: הורדלנד
-    hi: होर्डलैंड
-    hr: Hordaland
-    hu: Hordaland megye
-    hy: Հորդալան
-    id: Hordaland
-    is: Hörðaland
-    it: Hordaland
-    ja: ホルダラン県
-    ka: ჰორდალანი
-    kn: ಹೋರ್ಡಾಲ್ಯಾಂಡ್
-    ko: 호르달란 주
-    lt: Hordalandas
-    lv: Hordalanne
-    mr: हॉर्डालँड
-    ms: Hordaland
-    nb: Hordaland
-    ne: होर्डाल्यान्ड
-    nl: Hordaland
-    pl: Hordaland
-    pt: Hordaland
-    ro: Hordaland
-    ru: Хордаланн
-    si: හොර්ඩලන්තය
-    sk: Hordaland
-    sl: Hordaland
-    sr: Хордаланд
-    sv: Hordaland fylke
-    sw: Hordaland
-    ta: ஹார்டாலன்ட்
-    te: హోర్డాలాండ్
-    th: ฮอร์ดาแลนด์
-    tr: Hordaland
-    uk: Гордалан
-    ur: ہوردالان
-    vi: Hordaland
+    ar: موره ورومسدال
+    be: Мёрэ-ог-Румсдал
+    bg: Мьоре ог Ромсдал
+    ca: Møre og Romsdal
+    cs: Møre og Romsdal
+    da: Møre og Romsdal
+    de: Møre og Romsdal
+    en: Møre og Romsdal
+    es: Møre og Romsdal
+    et: Møre og Romsdal
+    eu: Møre og Romsdal
+    fa: مور او رومسدال
+    fi: Møren ja Romsdalin lääni
+    fr: Comté de Møre og Romsdal
+    hr: Møre og Romsdal
+    hu: Møre og Romsdal megye
+    id: Møre og Romsdal
+    is: Mæri og Raumsdalur
+    it: Møre og Romsdal
+    ja: ムーレ・オ・ロムスダール県
+    ka: მიორე-ოგ-რუმსდალი
+    ko: 뫼레오그롬스달 주
+    lt: Miorė ir Rumsdalis
+    lv: Mēre un Rumsdāle
+    nb: Møre og Romsdal
+    nl: Møre og Romsdal
+    pl: Møre og Romsdal
+    pt: Møre og Romsdal
+    ro: Møre og Romsdal
+    ru: Мёре-ог-Ромсдал
+    sk: Møre og Romsdal
+    sl: Møre og Romsdal
+    sr: Мере ог Ромсдал
+    sv: Møre og Romsdal fylke
+    sw: Møre og Romsdal
+    tr: Møre og Romsdal
+    uk: Мере-ог-Ромсдал
+    ur: مورہ او رومسدال
+    vi: Møre og Romsdal
+  geo:
+    latitude: 62.9760369
+    longitude: 8.018272399999999
+    min_latitude: 61.9565835
+    min_longitude: 5.263584499999999
+    max_latitude: 63.5377568
+    max_longitude: 9.5842118
+  name: Møre og Romsdal
 '18':
+  unofficial_names: Nordland
   translations:
     af: Nordland
     ar: نورلان
@@ -800,105 +375,16 @@ NO-22:
     uk: Нурлан
     ur: نودلان
     vi: Nordland
-'19':
-  translations:
-    af: Troms
-    ar: ترومس
-    be: Тромс
-    bg: Тромс
-    bn: ট্রোমস
-    ca: Troms
-    cs: Troms
-    da: Troms
-    de: Troms
-    el: Τρομς
-    en: Troms
-    es: Troms
-    et: Troms
-    eu: Troms
-    fa: ترومز
-    fi: Tromssan lääni
-    fr: Troms
-    gu: ટ્રોમ્સ
-    hi: ट्रोम्स
-    hr: Troms
-    hu: Troms megye
-    hy: Թրոմս
-    id: Troms
-    is: Tromsfylki
-    it: Troms
-    ja: トロムス県
-    ka: ტრომსი
-    kn: ಟ್ರೋಮ್ಸ್
-    ko: 트롬스 주
-    lt: Trumsas
-    lv: Trumse
-    mr: ट्रॉम्स
-    ms: Troms
-    nb: Troms
-    nl: Troms
-    pl: Troms
-    pt: Troms
-    ro: Troms
-    ru: Тромс
-    si: ට්‍රොම්ස්
-    sk: Troms
-    sl: Troms
-    sr: Тромс
-    sv: Troms fylke
-    ta: ட்ரோம்ஸ்
-    te: ట్రోమ్స్
-    th: ตรอมส์
-    tr: Troms
-    uk: Трумс
-    ur: ترومس
-    vi: Troms
-'20':
-  translations:
-    af: Finnmark
-    ar: فينمارك
-    be: Фінмарк
-    bg: Финмарк
-    ca: Finnmark
-    cs: Finnmark
-    da: Finnmark
-    de: Finnmark
-    en: Finnmark
-    es: Finnmark
-    et: Finnmark
-    eu: Finnmark
-    fa: فینمارک
-    fi: Finnmarkin lääni
-    fr: comté de Finnmark
-    he: פינמרק
-    hr: Finnmark
-    hu: Finnmark megye
-    hy: Ֆինմարք
-    id: Finnmark
-    is: Finnmörk
-    it: Finnmark
-    ja: フィンマルク県
-    ka: ფინმარკი
-    ko: 핀마르크 주
-    lt: Finmarkas
-    lv: Finnmarka
-    nb: Finnmark
-    nl: Finnmark
-    pl: Finnmark
-    pt: Finnmark
-    ro: Finnmark
-    ru: Финнмарк
-    sk: Finnmark
-    sl: Finnmark
-    sr: Финмарк
-    sv: Finnmark fylke
-    sw: Finnmark
-    th: เทศมณฑลฟินน์มาร์ก
-    tr: Finnmark
-    uk: Фінмарк
-    ur: فنمارک
-    vi: Finnmark
+  geo:
+    latitude: 67.69167019999999
+    longitude: 12.7019476
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Nordland
 '21':
+  unofficial_names: Svalbard (Arctic Region)
   translations:
     af: Svalbard
     ar: سفالبارد
@@ -911,7 +397,7 @@ NO-22:
     da: Svalbard
     de: Spitzbergen
     el: Αρχιπέλαγος Σβάλμπαρντ
-    en: Svalbard
+    en: Svalbard (Arctic Region)
     es: Svalbard
     et: Svalbard
     eu: Svalbard
@@ -956,7 +442,16 @@ NO-22:
     uk: Шпіцберген
     ur: سوالبارد
     vi: Svalbard
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Svalbard (Arctic Region)
 '22':
+  unofficial_names: Jan Mayen (Arctic Region)
   translations:
     af: Jan Mayen
     ar: جان ماين
@@ -1008,322 +503,506 @@ NO-22:
     uk: Ян-Маєн
     ur: جان ماین
     vi: Jan Mayen
-'08':
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Jan Mayen (Arctic Region)
+'30':
   translations:
-    ar: مقاطعة تلمارك
-    be: Тэлемарк
-    bg: Телемарк
-    ca: Telemark
-    cs: Telemark
-    da: Telemarken
-    de: Telemark
-    en: Telemark
-    es: Telemark
-    et: Telemark
-    eu: Telemark
-    fa: تلمارک
-    fi: Telemarkin lääni
-    fr: Comté de Telemark
-    hr: Telemark
-    hu: Telemark megye
-    id: Telemark
-    is: Þelamörk
-    it: Telemark
-    ja: テレマルク県
-    ka: ტელემარკი
-    ko: 텔레마르크 주
-    lt: Telemarkas
-    nb: Telemark
-    nl: Telemark
-    pl: Telemark
-    pt: Telemark
-    ro: Telemark
-    ru: Телемарк
-    sk: Telemark
-    sl: Telemark
-    sr: Телемарк
-    sv: Telemark fylke
-    ta: டெலிமார்க்
-    tr: Telemark
-    uk: Телемарк
-    ur: تیلیمارک
-    vi: Telemark
-'09':
+    ast: Viken
+    be-tarask: Вікен
+    ca: Viken (comtat)
+    cs: Viken
+    da: Viken
+    de: Viken
+    el: Βίκεν
+    en: Viken
+    es: Provincia de Viken
+    et: Vikeni maakond
+    fi: Vikenin fylke
+    fr: Viken
+    he: ויקן
+    is: Viken
+    it: Viken
+    ja: ヴィッケン県
+    ko: 비켄주
+    nb: Viken
+    nl: Viken
+    nn: Viken fylke
+    sgs: Viken
+    sk: Viken
+    sv: Viken
+    th: เทศมณฑลวีเกิน
+    uk: Вікен
+    zh: 維肯郡
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Viken
+'34':
   translations:
-    ar: أوست أغدر
-    be: Эўст-Агдэр
-    bg: Ауст-Агдер
-    ca: Aust-Agder
-    cs: Aust-Agder
-    da: Aust-Agder
-    de: Aust-Agder
-    en: Aust-Agder
-    es: Aust-Agder
-    et: Aust-Agder
-    eu: Aust-Agder
-    fa: اوست آدر
-    fi: Itä-Agderin lääni
-    fr: Comté d’Aust-Agder
-    hr: Aust-Agder
-    hu: Aust-Agder megye
-    id: Aust-Agder
-    is: Austur-Agðir
-    it: Aust-Agder
-    ja: アウスト・アグデル県
-    ka: ეუსტ-აგდერი
-    ko: 에우스트아그데르 주
-    lt: Rytų Agderis
-    nb: Aust-Agder
-    nl: Aust-Agder
-    pl: Aust-Agder
-    pt: Aust-Agder
-    ro: Aust-Agder
-    ru: Эуст-Агдер
-    sk: Aust-Agder
-    sl: Aust-Agder
-    sr: Источни Агдер
-    sv: Aust-Agder fylke
-    sw: Aust-Agder
-    tr: Aust-Agder
-    uk: Еуст-Аґдер
-    ur: آوست-آگدیر
-    vi: Aust-Agder
-'11':
+    aa: Innlandet
+    af: Innlandet
+    ak: Innlandet
+    aln: Innlandet
+    an: Innlandet
+    ang: Innlandet
+    arn: Innlandet
+    ast: Innlandet
+    ay: Innlandet
+    az: Innlandet
+    bar: Innlandet
+    bcl: Innlandet
+    bi: Innlandet
+    bjn: Innlandet
+    bm: Innlandet
+    br: Innlandet
+    brh: Innlandet
+    bs: Innlandet
+    ca: Innlandet
+    cbk-zam: Innlandet
+    cdo: Innlandet
+    ceb: Innlandet
+    ch: Innlandet
+    cho: Innlandet
+    chr: Innlandet
+    chy: Innlandet
+    co: Innlandet
+    cr: Innlandet
+    crh-latn: Innlandet
+    cs: Innlandet
+    csb: Innlandet
+    cy: Innlandet
+    da: Innlandet
+    de: Innlandet
+    de-at: Innlandet
+    de-ch: Innlandet
+    diq: Innlandet
+    dsb: Innlandet
+    dtp: Innlandet
+    ee: Innlandet
+    eml: Innlandet
+    en: Innlandet
+    en-ca: Innlandet
+    en-gb: Innlandet
+    eo: Innlandet
+    es: Innlandet
+    et: Innlandet
+    eu: Innlandet
+    ext: Innlandet
+    ff: Innlandet
+    fi: Innlandet
+    fit: Innlandet
+    fj: Innlandet
+    fo: Innlandet
+    fr: Innlandet
+    frp: Innlandet
+    frr: Innlandet
+    fur: Innlandet
+    fy: Innlandet
+    ga: Innlandet
+    gag: Innlandet
+    gd: Innlandet
+    gl: Innlandet
+    gn: Innlandet
+    got: Innlandet
+    gsw: Innlandet
+    ha: Innlandet
+    hak: Innlandet
+    haw: Innlandet
+    he: ינלנה
+    hif-latn: Innlandet
+    ho: Innlandet
+    hr: Innlandet
+    hsb: Innlandet
+    ht: Innlandet
+    hu: Innlandet
+    hy: Թեդի Պակ
+    hz: Innlandet
+    ia: Innlandet
+    id: Innlandet
+    ie: Innlandet
+    ig: Innlandet
+    ik: Innlandet
+    ike-latn: Innlandet
+    ilo: Innlandet
+    io: Innlandet
+    is: Innlandet
+    it: Innlandet
+    iu: Innlandet
+    ja: インラント県
+    jam: Innlandet
+    jbo: Innlandet
+    jv: Innlandet
+    kaa: Innlandet
+    kab: Innlandet
+    kg: Innlandet
+    ki: Innlandet
+    kj: Innlandet
+    kk-latn: Innlandet
+    kk-tr: Innlandet
+    kl: Innlandet
+    ko: 인란데주
+    kr: Innlandet
+    krj: Innlandet
+    ksh: Innlandet
+    ku: Innlandet
+    la: Innlandet
+    lad: Innlandet
+    lb: Innlandet
+    lfn: Innlandet
+    li: Innlandet
+    lij: Innlandet
+    lmo: Innlandet
+    ln: Innlandet
+    loz: Innlandet
+    lt: Innlandet
+    ltg: Innlandet
+    lus: Innlandet
+    lv: Innlandet
+    lzz: Innlandet
+    map-bms: Innlandet
+    mi: Innlandet
+    min: Innlandet
+    ms: Innlandet
+    mt: Innlandet
+    mus: Innlandet
+    mwl: Innlandet
+    na: Innlandet
+    nah: Innlandet
+    nap: Innlandet
+    nb: Innlandet
+    nds: Innlandet
+    nds-nl: Innlandet
+    ng: Innlandet
+    nl: Innlandet
+    nn: Innlandet
+    nov: Innlandet
+    nrm: Innlandet
+    nso: Innlandet
+    nv: Innlandet
+    ny: Innlandet
+    oc: Innlandet
+    om: Innlandet
+    pag: Innlandet
+    pam: Innlandet
+    pcd: Innlandet
+    pdc: Innlandet
+    pdt: Innlandet
+    pfl: Innlandet
+    pih: Innlandet
+    pl: Innlandet
+    pms: Innlandet
+    prg: Innlandet
+    ps: اينلانه
+    pt: Innlandet
+    pt-br: Innlandet
+    qu: Innlandet
+    qug: Innlandet
+    rif: Innlandet
+    rm: Innlandet
+    rmy: Innlandet
+    rn: Innlandet
+    ro: Innlandet
+    roa-tara: Innlandet
+    ru: Иннландет
+    rup: Innlandet
+    ruq-latn: Innlandet
+    rw: Innlandet
+    sat: Innlandet
+    sc: Innlandet
+    scn: Innlandet
+    sco: Innlandet
+    sdc: Innlandet
+    se: Innlandet
+    sei: Innlandet
+    sg: Innlandet
+    sgs: Innlandet
+    sh: Innlandet
+    shi-latn: Innlandet
+    sk: Innlandet
+    sl: Innlandet
+    sli: Innlandet
+    sm: Innlandet
+    sma: Innlandet
+    sn: Innlandet
+    so: Innlandet
+    sq: Innlandet
+    sr-el: Innlandet
+    srn: Innlandet
+    st: Innlandet
+    stq: Innlandet
+    sv: Innlandet
+    sw: Innlandet
+    szl: Innlandet
+    tet: Innlandet
+    tg-latn: Innlandet
+    th: เทศมณฑลอินลันเนอ
+    tk: Innlandet
+    tl: Innlandet
+    tn: Innlandet
+    to: Innlandet
+    tpi: Innlandet
+    tr: Innlandet
+    tru: Innlandet
+    ts: Innlandet
+    tt-latn: Innlandet
+    tum: Innlandet
+    ty: Innlandet
+    ug-latn: Innlandet
+    uk: Іннланне
+    uz: Innlandet
+    ve: Innlandet
+    vec: Innlandet
+    vep: Innlandet
+    vi: Innlandet
+    vls: Innlandet
+    vmf: Innlandet
+    vo: Innlandet
+    vot: Innlandet
+    wa: Innlandet
+    war: Innlandet
+    wo: Innlandet
+    xh: Innlandet
+    yo: Innlandet
+    za: Innlandet
+    zea: Innlandet
+    zh: 內陸郡
+    zu: Innlandet
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Innlandet
+'38':
   translations:
-    ar: روغالاند
-    be: Ругалан
-    bg: Ругалан
-    ca: Rogaland
-    cs: Rogaland
-    da: Rogaland
-    de: Rogaland
-    en: Rogaland
-    es: Rogaland
-    et: Rogaland
-    eu: Rogaland
-    fa: روگالاند
-    fi: Rogalandin lääni
-    fr: comté de Rogaland
-    he: רוגלנד
-    hr: Rogaland
-    hu: Rogaland megye
-    hy: Ռուգլան
-    id: Rogaland
-    is: Rogaland
-    it: Rogaland
-    ja: ローガラン県
-    ka: რუგალანი
-    ko: 로갈란 주
-    lt: Rugalandas
-    lv: Rūgalanne
-    nb: Rogaland
-    nl: Rogaland
-    pl: Rogaland
-    pt: Rogaland
-    ro: Rogaland
-    ru: Ругаланн
-    sk: Rogaland
-    sl: Rogaland
-    sr: Рогаланд
-    sv: Rogaland fylke
-    sw: Rogaland
-    tr: Rogaland
-    uk: Руґалан
-    ur: روگالان
-    vi: Rogaland
-'14':
+    ast: Vestfold og Telemark
+    cs: Vestfold og Telemark
+    da: Vestfold og Telemark
+    de: Vestfold og Telemark
+    de-ch: Vestfold og Telemark
+    el: Βέστφολντ ογκ Τέλεμαρκ
+    en: Vestfold og Telemark
+    en-ca: Vestfold og Telemark
+    en-gb: Vestfold og Telemark
+    es: Provincia de Vestfold og Telemark
+    et: Vestfold og Telemargi maakond
+    fr: Vestfold og Telemark
+    he: וסטפול וטלמרק
+    is: Vestfold og Þelamörk
+    it: Vestfold og Telemark
+    ja: ヴェストフォル・オ・テレマルク県
+    ko: 베스트폴오그텔레마르크주
+    nb: Vestfold og Telemark
+    nl: Vestfold og Telemark
+    nn: Vestfold og Telemark fylke
+    pt: Vestfold og Telemark
+    sv: Vestfold og Telemark
+    th: เทศมณฑลเว็สต์ฟ็อลและเทเลอมาร์ก
+    uk: Вестфолд-ог-Телемарк
+    zh: 西福尔-泰勒马克郡
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Vestfold og Telemark
+'42':
   translations:
-    ar: سوغن و فيوردانه
-    bg: Согн ог Фьоране
-    bn: সং অফ ফুরডান
-    ca: Sogn og Fjordane
-    cs: Sogn og Fjordane
-    da: Sogn og Fjordane
-    de: Sogn og Fjordane
-    el: Σόγνκ ογκ Φτζορντάνε
-    en: Sogn og Fjordane
-    es: Sogn og Fjordane
-    et: Sogn og Fjordane
-    eu: Sogn og Fjordane
-    fa: سون اوگ فوردان
-    fi: Sognin ja Fjordanen lääni
-    fr: Comté de Sogn og Fjordane
-    gu: સોગન ઓગ ફજોર્ડન
-    he: סוגן אוג פיורדנה
-    hi: सॉयन ऑग फ्योर्डेन
-    hr: Sogn og Fjordane
-    hu: Sogn og Fjordane megye
-    id: Sogn og Fjordane
-    is: Sogn og Firðafylki
-    it: Sogn og Fjordane
-    ja: ソグン・オ・フィヨーラネ県
-    ka: სოგნ-ოგ-ფიურანე
-    kn: ಸೊಗ್ನ್ ಓಗ್ ಫೋರ್ಜಾರ್ನೆ
-    ko: 송노피오라네 주
-    lt: Sognė ir Fjurdanė
-    lv: Sogna un Fjūrane
-    mr: सॉगन ओग फँजोरदाने
-    ms: Sogn og Fjordane
-    nb: Sogn og Fjordane
-    nl: Sogn og Fjordane
-    pl: Sogn og Fjordane
-    pt: Sogn og Fjordane
-    ro: Sogn og Fjordane
-    ru: Согн-ог-Фьюране
-    si: සොග්න් ඔග් ෆ්ජෝර්දනේ
-    sk: Sogn og Fjordane
-    sl: Sogn og Fjordane
-    sr: Согн ог Фјордане
-    sv: Sogn og Fjordane fylke
-    sw: Sogn og Fjordane
-    ta: சோங் ஓக் பிஜோர்தானே
-    te: సాన్ ఆఫ్ ఫ్యూర్డీన్
-    th: สง อ๊ก ฟจอร์ดัน
-    tr: Sogn og Fjordane
-    uk: Согн-ог-Фʼюране
-    ur: سونگ او فیورانہ
-    vi: Sogn og Fjordane
-'15':
+    af: Agder
+    ast: Agder
+    br: Agder
+    cs: Agder
+    da: Agder
+    de: Agder
+    el: Άγκντερ
+    en: Agder
+    es: Reino de Agder
+    et: Agder
+    fi: Agder
+    fr: Agder
+    fy: Agder
+    he: אגדר
+    hy: Ագդեր
+    is: Agðir
+    it: Agder
+    ja: アグデル
+    ko: 아그데르주
+    lb: Agder
+    nb: Agder
+    nds: Agder
+    nds-nl: Agder
+    nl: Agder
+    nn: Agder
+    pl: Agder
+    pnb: اگدر
+    sv: Agder
+    ta: அக்டர்
+    th: เทศมณฑลอักเดอร์
+    uk: Агдер
+    zh: 阿格德爾
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Agder
+'46':
   translations:
-    ar: موره ورومسدال
-    be: Мёрэ-ог-Румсдал
-    bg: Мьоре ог Ромсдал
-    ca: Møre og Romsdal
-    cs: Møre og Romsdal
-    da: Møre og Romsdal
-    de: Møre og Romsdal
-    en: Møre og Romsdal
-    es: Møre og Romsdal
-    et: Møre og Romsdal
-    eu: Møre og Romsdal
-    fa: مور او رومسدال
-    fi: Møren ja Romsdalin lääni
-    fr: Comté de Møre og Romsdal
-    hr: Møre og Romsdal
-    hu: Møre og Romsdal megye
-    id: Møre og Romsdal
-    is: Mæri og Raumsdalur
-    it: Møre og Romsdal
-    ja: ムーレ・オ・ロムスダール県
-    ka: მიორე-ოგ-რუმსდალი
-    ko: 뫼레오그롬스달 주
-    lt: Miorė ir Rumsdalis
-    lv: Mēre un Rumsdāle
-    nb: Møre og Romsdal
-    nl: Møre og Romsdal
-    pl: Møre og Romsdal
-    pt: Møre og Romsdal
-    ro: Møre og Romsdal
-    ru: Мёре-ог-Ромсдал
-    sk: Møre og Romsdal
-    sl: Møre og Romsdal
-    sr: Мере ог Ромсдал
-    sv: Møre og Romsdal fylke
-    sw: Møre og Romsdal
-    tr: Møre og Romsdal
-    uk: Мере-ог-Ромсдал
-    ur: مورہ او رومسدال
-    vi: Møre og Romsdal
-'16':
+    af: Vestland
+    ast: Vestland
+    ca: Vestland
+    cs: Vestland
+    da: Vestland
+    de: Vestland
+    en: Vestland
+    es: Provincia de Vestland"
+    fa: وستلند
+    fr: Vestland
+    he: וסטלן
+    is: Vesturland (fylki í Noregi)
+    it: Vestland
+    ja: ヴェストラン県
+    ko: 베스트란주
+    nb: Vestland
+    nl: Vestland
+    nn: Vestland fylke
+    pl: Vestland
+    pt: Vestland
+    ru: Вестланн
+    sv: Vestland
+    th: เทศมณฑลเว็สต์ลัน
+    uk: Вестланн
+    zh: 韋斯特蘭郡
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Vestland
+'50':
   translations:
-    ar: سور ترونديلاغ
-    be: Сёр-Трондэлаг
-    bg: Сьор-Трьонелаг
-    bn: সোর-ট্রোডালেগ
-    ca: Sør-Trøndelag
-    cs: Sør-Trøndelag
-    da: Sør-Trøndelag
-    de: Sør-Trøndelag
-    el: Σορ-Τροντελάγκ
-    en: Sør-Trøndelag
-    es: Sør-Trøndelag
-    et: Sør-Trøndelag
-    eu: Sør-Trøndelag
-    fa: سور تروندلاگ
-    fi: Etelä-Trøndelagin lääni
-    fr: comté de Sør-Trøndelag
-    gu: સૉર-ટ્રોન્ડેલગ
-    hi: सुर-त्रोंदेलाग
-    hr: Sør-Trøndelag
-    hu: Sør-Trøndelag megye
-    id: Sør-Trøndelag
-    is: Suður-Þrændalög
-    it: Sør-Trøndelag
-    ja: ソール・トロンデラーグ県
-    ka: სიორ-ტრიონდელაგი
-    kn: ಸೊರ್-ಟ್ರಾಂಡೆಲಾಗ್
-    ko: 쇠르트뢰넬라그 주
-    lt: Pietų Triondelagas
-    mr: सोर-ट्रॉन्डेलॅग
-    ms: Sor-Trondelag
-    nb: Sør-Trøndelag
-    nl: Sør-Trøndelag
-    pl: Sør-Trøndelag
-    pt: Sør-Trøndelag
-    ro: Sør-Trøndelag
-    ru: Сёр-Трёнделаг
-    si: සොර්-ට්‍රෝන්ඩෙලාග්
-    sk: Sør-Trøndelag
-    sl: Sør-Trøndelag
-    sr: Јужни Тренделаг
-    sv: Sør-Trøndelag fylke
-    ta: சார்-ட்ரொண்டெலெக்
-    te: సోర్-ట్రోండెలాగ్
-    th: ซอร์-ทรอนเดราก
-    tr: Sør-Trøndelag
-    uk: Сер-Тренделаг
-    ur: جنوبی-تروندیلاگ
-    vi: Sør-Trøndelag
-'17':
+    ang: Þrondham
+    ar: تروندلاغ
+    ast: Trøndelag
+    azb: تروندلاق
+    be: Рэгіён Трондэлаг
+    ca: Trøndelag
+    cs: Trøndelag
+    da: Trøndelag
+    de: Trøndelag
+    diq: Trøndelag
+    el: Τρόντελαγκ
+    en: Trøndelag
+    eo: Trøndelag
+    es: Trøndelag
+    et: Trøndelag
+    fa: تروندلاگ
+    fi: Trøndelagin fylke
+    fo: Trøndelag fylki
+    fr: Trøndelag
+    fy: Trøndelag
+    he: נורבגיה התיכונה
+    hu: Trøndelag
+    hy: Տրյոնդելագ
+    is: Þrændalög
+    it: Trøndelag
+    ja: トロンデラーグ
+    ka: ტრიონდელაგი
+    ko: 트뢰넬라그
+    li: Trøndelag
+    lt: Triondelagas
+    lv: Trendelāga
+    mk: Тренделаг
+    nb: Trøndelag
+    nl: Trøndelag
+    nn: Trøndelag
+    os: Централон Норвеги
+    pl: Trøndelag
+    pt: Trøndelag
+    ro: Trøndelag
+    ru: Трёнделаг
+    se: Trøndelága
+    sk: Trøndelag
+    sl: Trøndelag
+    sma: Trööndelage
+    sq: Trøndelag
+    sv: Trøndelag
+    th: เทศมณฑลเทรินเดอลาก
+    tr: Trøndelag
+    tt: Трөнделаг
+    uk: Треннелаг
+    ur: تروندیلاگ
+    zh: 特倫德拉格
+    zh-cn: 特伦德拉格
+    zh-hans: 特伦德拉格
+    zh-hant: 特倫德拉格
+    zh-hk: 特倫德拉格
+    zh-sg: 特伦德拉格
+    zh-tw: 特倫德拉格
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Trøndelag
+'54':
   translations:
-    ar: نور تروندلاغ
-    be: Нур-Трондэлаг
-    bg: Нор-Трьонелаг
-    bn: নর্ড-ট্রন্ডেলাগ
-    ca: Nord-Trøndelag
-    cs: Nord-Trøndelag
-    da: Nord-Trøndelag
-    de: Nord-Trøndelag
-    el: Νόρντ-Τροντελάγκ
-    en: Nord-Trøndelag
-    es: Nord-Trøndelag
-    et: Nord-Trøndelag
-    eu: Nord-Trøndelag
-    fa: نورد تروندلاگ
-    fi: Pohjois-Trøndelagin lääni
-    fr: Comté de Nord-Trøndelag
-    gu: નોર્ડ-ટ્રોન્ડેલાગ
-    hi: नोर्ड-ट्रॉन्डेलैग
-    hr: Nord-Trøndelag
-    hu: Nord-Trøndelag megye
-    hy: Նուր Տրյոնդելագ
-    id: Nord-Trøndelag
-    is: Norður-Þrændalög
-    it: Nord-Trøndelag
-    ja: ヌール・トロンデラーグ県
-    ka: ნურ-ტრიონდელაგი
-    kn: ನಾರ್ಡ್-ಟ್ರೋಂಡೆಲಾಗ್
-    ko: 노르트뢰넬라그 주
-    lt: Šiaurės Triondelagas
-    lv: Nūrtrendelāga
-    mr: नॉर्ड-ट्रॉन्डेलॅग
-    ms: Trondelag Utara
-    nb: Nord-Trøndelag
-    nl: Nord-Trøndelag
-    pl: Nord-Trøndelag
-    pt: Nord-Trøndelag
-    ro: Nord-Trøndelag
-    ru: Нур-Трёнделаг
-    si: නෝර්ඩ්-ට්රෝන්දෙලග්
-    sk: Nord-Trøndelag
-    sl: Nord-Trøndelag
-    sr: Северни Тренделаг
-    sv: Nord-Trøndelag fylke
-    sw: Nord-Trøndelag
-    ta: நோர்ட -ட்ரொண்டெலெக்
-    te: నార్డ్-ట్రోండెలాగ్
-    th: นอร์ด-เทรินเดลาก
-    tr: Nord-Trøndelag
-    uk: Нур-Тренделаг
-    ur: شمالی-تروندیلاگ
-    vi: Nord-Trøndelag
+    ast: Troms og Finnmark
+    cs: Troms a Finnmark
+    da: Troms og Finnmark
+    de: Troms og Finnmark
+    de-ch: Troms og Finnmark
+    el: Τρομς ογκ Φίνμαρκ
+    en: Troms og Finnmark fylke
+    en-ca: Troms og Finnmark
+    en-gb: Troms og Finnmark
+    es: Provincia de Troms y Finnmark
+    et: Troms og Finnmargi maakond
+    fi: Tromssan ja Finnmarkin lääni
+    fkv: Tromssa ja Finmarkku
+    fr: Comté de Troms et Finnmark
+    he: טרומס ופינמרק
+    hu: Troms og Finnmark
+    is: Troms og Finnmörk
+    it: Troms og Finnmark
+    ja: トロムス・オ・フィンマルク県
+    ko: 트롬스오그핀마르크주
+    nb: Troms og Finnmark
+    nl: Troms og Finnmark
+    nn: Troms og Finnmark
+    pl: Troms og Finnmark
+    pt: Troms og Finnmark
+    ru: Тромс и Финнмарк
+    se: Romsa ja Finnmárku
+    sv: Troms og Finnmark
+    th: เทศมณฑลทรุมส์และฟินมาร์ก
+    uk: Тромс-ог-Фіннмарк
+    zh: 特罗姆斯-芬马克郡
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Troms og Finnmark


### PR DESCRIPTION
As of 2020-11-24, the iso codes have been dramatically updated for Norway, see the bottom of [this page](https://www.iso.org/obp/ui/#iso:code:3166:NO) under "Change history of country code."

The translations were all pulled from https://query.wikidata.org