### PR TITLE
Add `#in_esm?` property for countries in the European Single Market

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -78,6 +78,10 @@ module ISO3166
       data['eea_member'].nil? ? false : data['eea_member']
     end
 
+    def in_esm?
+      data['esm_member'].nil? ? in_eea? : data['esm_member']
+    end
+
     def to_s
       data['name']
     end

--- a/lib/countries/data/countries/AT.yaml
+++ b/lib/countries/data/countries/AT.yaml
@@ -38,7 +38,7 @@ AT:
     standard: 20
     reduced:
     - 10
-    super_reduced: 
+    super_reduced:
     parking: 12
   postal_code: true
   postal_code_format: "\\d{4}"

--- a/lib/countries/data/countries/BE.yaml
+++ b/lib/countries/data/countries/BE.yaml
@@ -32,7 +32,7 @@ BE:
     reduced:
     - 6
     - 12
-    super_reduced: 
+    super_reduced:
     parking: 12
   postal_code: true
   postal_code_format: "\\d{4}"

--- a/lib/countries/data/countries/BG.yaml
+++ b/lib/countries/data/countries/BG.yaml
@@ -32,8 +32,8 @@ BG:
     standard: 20
     reduced:
     - 9
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:

--- a/lib/countries/data/countries/CH.yaml
+++ b/lib/countries/data/countries/CH.yaml
@@ -25,14 +25,14 @@ CH:
   world_region: EMEA
   un_locode: CH
   nationality: Swiss
-  eea_member: true
+  esm_member: true
   vat_rates:
     standard: 7.7
     reduced:
     - 2.5
     - 3.7
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:

--- a/lib/countries/data/countries/CY.yaml
+++ b/lib/countries/data/countries/CY.yaml
@@ -26,8 +26,8 @@ CY:
     reduced:
     - 5
     - 9
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:

--- a/lib/countries/data/countries/CZ.yaml
+++ b/lib/countries/data/countries/CZ.yaml
@@ -30,8 +30,8 @@ CZ:
     standard: 21
     reduced:
     - 15
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{3} ?\\d{2}"
   unofficial_names:

--- a/lib/countries/data/countries/DE.yaml
+++ b/lib/countries/data/countries/DE.yaml
@@ -38,8 +38,8 @@ DE:
     standard: 19
     reduced:
     - 7
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:

--- a/lib/countries/data/countries/DK.yaml
+++ b/lib/countries/data/countries/DK.yaml
@@ -30,8 +30,8 @@ DK:
   vat_rates:
     standard: 25
     reduced: []
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:

--- a/lib/countries/data/countries/EE.yaml
+++ b/lib/countries/data/countries/EE.yaml
@@ -26,8 +26,8 @@ EE:
     standard: 20
     reduced:
     - 9
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:

--- a/lib/countries/data/countries/ES.yaml
+++ b/lib/countries/data/countries/ES.yaml
@@ -32,7 +32,7 @@ ES:
     reduced:
     - 10
     super_reduced: 4
-    parking: 
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:

--- a/lib/countries/data/countries/FI.yaml
+++ b/lib/countries/data/countries/FI.yaml
@@ -31,8 +31,8 @@ FI:
     reduced:
     - 10
     - 14
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:

--- a/lib/countries/data/countries/FR.yaml
+++ b/lib/countries/data/countries/FR.yaml
@@ -33,7 +33,7 @@ FR:
     - 5.5
     - 10
     super_reduced: 2.1
-    parking: 
+    parking:
   postal_code: true
   postal_code_format: "\\d{2} ?\\d{3}"
   unofficial_names:

--- a/lib/countries/data/countries/GR.yaml
+++ b/lib/countries/data/countries/GR.yaml
@@ -31,8 +31,8 @@ GR:
     reduced:
     - 6
     - 13
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{3} ?\\d{2}"
   unofficial_names:

--- a/lib/countries/data/countries/HR.yaml
+++ b/lib/countries/data/countries/HR.yaml
@@ -31,8 +31,8 @@ HR:
     reduced:
     - 5
     - 13
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:

--- a/lib/countries/data/countries/HU.yaml
+++ b/lib/countries/data/countries/HU.yaml
@@ -33,8 +33,8 @@ HU:
     reduced:
     - 5
     - 18
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:

--- a/lib/countries/data/countries/IS.yaml
+++ b/lib/countries/data/countries/IS.yaml
@@ -31,8 +31,8 @@ IS:
     standard: 24
     reduced:
     - 11
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{3}"
   unofficial_names:

--- a/lib/countries/data/countries/IT.yaml
+++ b/lib/countries/data/countries/IT.yaml
@@ -32,7 +32,7 @@ IT:
     reduced:
     - 10
     super_reduced: 4
-    parking: 
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:

--- a/lib/countries/data/countries/LT.yaml
+++ b/lib/countries/data/countries/LT.yaml
@@ -26,8 +26,8 @@ LT:
     reduced:
     - 5
     - 9
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:

--- a/lib/countries/data/countries/LV.yaml
+++ b/lib/countries/data/countries/LV.yaml
@@ -31,8 +31,8 @@ LV:
     standard: 21
     reduced:
     - 12
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: LV-\d{4}
   unofficial_names:

--- a/lib/countries/data/countries/MT.yaml
+++ b/lib/countries/data/countries/MT.yaml
@@ -26,8 +26,8 @@ MT:
     reduced:
     - 5
     - 7
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "[A-Z]{3} ?\\d{2,4}"
   unofficial_names:

--- a/lib/countries/data/countries/NL.yaml
+++ b/lib/countries/data/countries/NL.yaml
@@ -30,8 +30,8 @@ NL:
     standard: 21
     reduced:
     - 6
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4} ?[A-Z]{2}"
   unofficial_names:

--- a/lib/countries/data/countries/NO.yaml
+++ b/lib/countries/data/countries/NO.yaml
@@ -28,8 +28,8 @@
   vat_rates:
     standard: 25
     reduced: []
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:

--- a/lib/countries/data/countries/PL.yaml
+++ b/lib/countries/data/countries/PL.yaml
@@ -32,8 +32,8 @@ PL:
     reduced:
     - 5
     - 8
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{2}-\\d{3}"
   unofficial_names:

--- a/lib/countries/data/countries/PT.yaml
+++ b/lib/countries/data/countries/PT.yaml
@@ -31,7 +31,7 @@ PT:
     reduced:
     - 6
     - 13
-    super_reduced: 
+    super_reduced:
     parking: 13
   postal_code: true
   postal_code_format: "\\d{4}-\\d{3}"

--- a/lib/countries/data/countries/RO.yaml
+++ b/lib/countries/data/countries/RO.yaml
@@ -31,8 +31,8 @@ RO:
     reduced:
     - 5
     - 9
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{6}"
   unofficial_names:

--- a/lib/countries/data/countries/SE.yaml
+++ b/lib/countries/data/countries/SE.yaml
@@ -31,8 +31,8 @@ SE:
     reduced:
     - 6
     - 12
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{3} ?\\d{2}"
   unofficial_names:

--- a/lib/countries/data/countries/SI.yaml
+++ b/lib/countries/data/countries/SI.yaml
@@ -30,8 +30,8 @@ SI:
     standard: 22
     reduced:
     - 9.5
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:

--- a/lib/countries/data/countries/SK.yaml
+++ b/lib/countries/data/countries/SK.yaml
@@ -30,8 +30,8 @@ SK:
     standard: 20
     reduced:
     - 10
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{3} ?\\d{2}"
   unofficial_names:

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -838,6 +838,23 @@ describe ISO3166::Country do
     end
   end
 
+  describe 'in_esm?' do
+    let(:netherlands) { ISO3166::Country.search('NL') }
+    let(:switzerland) { ISO3166::Country.search('CH') }
+
+    it 'should return false for countries without esm_member or eea_member flag' do
+      expect(country.in_esm?).to be_falsey
+    end
+
+    it 'should return true for countries with eea_member flag set to true' do
+      expect(netherlands.in_esm?).to be_truthy
+    end
+
+    it 'should return true for countries with esm_member flag set to true' do
+      expect(switzerland.in_esm?).to be_truthy
+    end
+  end
+
   describe 'gec' do
     it 'should return the country\'s GEC code' do
       expect(ISO3166::Country.new('NA').gec).to eql 'WA'


### PR DESCRIPTION
I've used `in_eea?` in the past as a way to determine European Single Market membership, but PR #676 correctly states that Switzerland is not an EEA member, but is a member of the ESM.

This PR adds `#in_esm?` property for counties in the European Single Market, delegating to `in_eea?` if the property is unset.