### PR TITLE
CH is not part of the EEA

### DIFF
--- a/lib/countries/data/countries/CH.yaml
+++ b/lib/countries/data/countries/CH.yaml
@@ -25,7 +25,6 @@ CH:
   world_region: EMEA
   un_locode: CH
   nationality: Swiss
-  eea_member: true
   vat_rates:
     standard: 7.7
     reduced:


### PR DESCRIPTION
> The EEA includes EU countries and also Iceland, Liechtenstein and Norway. It allows them to be part of the EU’s single market.
> 
> Switzerland is not an EU or EEA member but is part of the single market. This means Swiss nationals have the same rights to live and work in the UK as other EEA nationals.
> 

Source: https://www.gov.uk/eu-eea