### PR TITLE
Adds North Korea to list of unofficial names of KP

### DIFF
--- a/lib/countries/data/countries/KP.yaml
+++ b/lib/countries/data/countries/KP.yaml
@@ -23,6 +23,7 @@ KP:
   postal_code: false
   unofficial_names:
   - Korea (North)
+  - North Korea
   - Nordkorea
   - Corée du Nord
   - Corea del Norte


### PR DESCRIPTION
It is pretty common to call `Democratic People's Republic of Korea` `North Korea` yet it is not present in the list of unofficial name and if we try to find country data for `North Korea` we get `nil` instead which leads to unexpected errors. Adding North Korea to the list of unofficial names improves accuracy of the matches and also fixes these issues.