### PR TITLE
Fix ISO3166::Data.register loading of nested hashes, eg: geo data.

### DIFF
--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -26,8 +26,7 @@ module ISO3166
 
       def register(data)
         alpha2 = data[:alpha2].upcase
-        @@registered_data[alpha2] = \
-          data.each_with_object({}) { |(k, v), a| a[k.to_s] = v }
+        @@registered_data[alpha2] = deep_stringify_keys(data)
         @@registered_data[alpha2]['translations'] = \
           Translations.new.merge(data[:translations] || {})
         @@cache = cache.merge(@@registered_data)
@@ -161,6 +160,14 @@ module ISO3166
 
       def datafile_path(file_array)
         File.join([@@cache_dir] + file_array)
+      end
+
+      def deep_stringify_keys(data)
+        data.transform_keys!(&:to_s)
+        data.transform_values! do |v|
+          v.is_a?(Hash) ? deep_stringify_keys(v) : v
+        end
+        return data
       end
     end
   end

--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -28,7 +28,7 @@ module ISO3166
         alpha2 = data[:alpha2].upcase
         @@registered_data[alpha2] = deep_stringify_keys(data)
         @@registered_data[alpha2]['translations'] = \
-          Translations.new.merge(data[:translations] || {})
+          Translations.new.merge(data['translations'] || {})
         @@cache = cache.merge(@@registered_data)
       end
 

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -116,8 +116,8 @@ describe ISO3166::Data do
       expect(subject.name).to eq 'NEW Taiwan'
       expect(subject.translations).to eq('en' => 'NEW Taiwan',
                                          'de' => 'NEW Taiwan')
-      expect(subject.subdivisions).to eq(CHA: ISO3166::Subdivision.new({name: 'New Changhua'}),
-                                         CYI: ISO3166::Subdivision.new({name: 'New Municipality'}))
+      expect(subject.subdivisions).to eq('CHA' => ISO3166::Subdivision.new({name: 'New Changhua'}),
+                                         'CYI' => ISO3166::Subdivision.new({name: 'New Municipality'}))
     end
   end
 
@@ -143,8 +143,8 @@ describe ISO3166::Data do
       data = ISO3166::Data.new('LOL').call
       expect(data['name']).to eq 'Happy Country'
       expect(subject.name).to eq 'Happy Country'
-      expect(subject.subdivisions).to eq(LOL1: ISO3166::Subdivision.new({name: 'Happy sub1'}),
-                                         LOL2: ISO3166::Subdivision.new({name: 'Happy sub2'}))
+      expect(subject.subdivisions).to eq('LOL1' => ISO3166::Subdivision.new({name: 'Happy sub1'}),
+                                         'LOL2' => ISO3166::Subdivision.new({name: 'Happy sub2'}))
     end
 
     it 'detect a stale cache' do


### PR DESCRIPTION
This addresses the issue mentioned in https://github.com/countries/countries/pull/397#issuecomment-846543094

(cc @kg-currenxie)