### PR TITLE
Update CZ.yaml: Czechia is the ISO short name for the Czech Republic

### DIFF
--- a/lib/countries/data/countries/CZ.yaml
+++ b/lib/countries/data/countries/CZ.yaml
@@ -12,7 +12,7 @@ CZ:
   international_prefix: '00'
   ioc: CZE
   gec: EZ
-  name: Czech Republic
+  name: Czechia
   national_destination_code_lengths:
   - 2
   national_number_lengths:


### PR DESCRIPTION
Fixes #688 

While there are probably still some inconsistencies, we tend to use the ISO short name instead of the ISO full name for the `name` attribute.