### PR TITLE
Fix regression in `ISO3166::Country.translations` with symbols

### DIFF
--- a/lib/countries/translations.rb
+++ b/lib/countries/translations.rb
@@ -6,7 +6,7 @@ module ISO3166
   # to `pt` to prevent from showing nil values
   class Translations < Hash
     def [](locale)
-      super(locale) || super(locale.sub(/-.*/, ''))
+      super(locale) || super(locale.to_s.sub(/-.*/, ''))
     end
   end
 end


### PR DESCRIPTION
Fix error when getting ISO3166::Country.translations with a symbol instead of a string when there are custom countries registered.

Fixes #691