### PR TITLE
Update NL reduced VAT rate

### DIFF
--- a/lib/countries/data/countries/NL.yaml
+++ b/lib/countries/data/countries/NL.yaml
@@ -29,7 +29,7 @@ NL:
   vat_rates:
     standard: 21
     reduced:
-    - 6
+    - 9
     super_reduced:
     parking:
   postal_code: true


### PR DESCRIPTION
The Dutch reduced VAT rate was increased from 6% to 9% in 2019: https://www.government.nl/topics/vat/reduced-vat-rate-to-increase-from-6-to-9

Here are todays tariffs: https://www.belastingdienst.nl/wps/wcm/connect/bldcontenten/belastingdienst/business/vat/vat_in_the_netherlands/calculating_vat/vat_tariffs