### PR TITLE
Ensure Moscow Oblast translations reference the "province"

### DIFF
--- a/lib/countries/data/subdivisions/RU.yaml
+++ b/lib/countries/data/subdivisions/RU.yaml
@@ -3423,7 +3423,7 @@ MOS:
     mn: Москва муж
     mr: मॉस्को ओब्लास्त
     ms: Wilayah Moscow
-    nb: Moskva
+    nb: Moskva oblast
     nl: Oblast Moskou
     pl: Obwód moskiewski
     pt: Oblast de Moscou
@@ -3440,7 +3440,7 @@ MOS:
     tr: Moskova Oblastı
     uk: Московська область
     ur: ماسکو اوبلاست
-    vi: Moskva
+    vi: Moskva (tỉnh)
     zh: 莫斯科州
     cy: Oblast Moscfa
     ceb: Moscow Oblast


### PR DESCRIPTION
Ensure that all translations of Moscow Oblast make reference to the fact that it's an "Oblast" or province, so that it is not confused with the city.

I attach the sources:

Netherland: https://no.wikipedia.org/wiki/Moskva_oblast

Thai: https://vi.wikipedia.org/wiki/Moskva_(tỉnh)

![Screenshot 2021-07-28 at 17 32 51](https://user-images.githubusercontent.com/1800981/127351619-988dcefc-9fb9-400f-a59b-e9fcc55ed1da.png)
