### PR TITLE
Update New Zealand's continent to Zealandia

### DIFF
--- a/lib/countries/data/countries/NZ.yaml
+++ b/lib/countries/data/countries/NZ.yaml
@@ -1,6 +1,6 @@
 ---
 NZ:
-  continent: Australia
+  continent: Zealandia
   address_format: |-
     {{recipient}}
     {{street}}


### PR DESCRIPTION
The continent returned for New Zealand is out of date with the latest scientific consensus, see: https://en.wikipedia.org/wiki/Zealandia#Classification_as_a_continent

> In 2017, a team of eleven geologists from New Zealand, New Caledonia, and Australia concluded that Zealandia fulfills all the requirements to be considered a submerged continent, rather than a microcontinent or continental fragment.[6] This verdict was widely covered by news media.