### PR TITLE
Update NZ subdivision data and fix Chatham Island entry

### DIFF
--- a/lib/countries/data/subdivisions/NZ.yaml
+++ b/lib/countries/data/subdivisions/NZ.yaml
@@ -181,6 +181,73 @@ CAN:
     mk: Кантербери
     'no': Canterbury
   comments:
+CIT:
+  name: Chatham Islands Territory
+  code:
+  unofficial_names:
+  geo:
+    latitude: -43.9120964
+    longitude: -176.5433025
+    min_latitude: -44.4343162
+    min_longitude: -176.8940878
+    max_latitude: -43.5631344
+    max_longitude: -175.8314073
+  translations:
+    ar: جزر تشاتام
+    az: Çatem
+    be: Астравы Чатэм
+    bg: Чатъм
+    bn: চ্যাথাম আইল্যান্ডস
+    ca: Illes Chatham
+    cs: Chathamské ostrovy
+    da: Chatham Øerne
+    de: Chathaminseln
+    el: Νησιά Τσάταμ
+    en: Chatham Islands
+    es: Islas Chatham
+    et: Chathami saared
+    eu: Chatham Islands
+    fa: جزایر چاتام
+    fi: Chathamsaaret
+    fr: Îles Chatham
+    gl: Illas Chatham
+    gu: ચૅથમ આઇલેન્ડ્સ
+    he: איי צ׳טהאם
+    hi: चाथम द्वीपसमूह
+    hr: Chathamski otoci
+    hu: Chatham-szigetek
+    hy: Չաթեմ կղզիներ
+    id: Kepulauan Chatham
+    it: Isole Chatham
+    ja: チャタム諸島
+    ka: ჩატემის კუნძულები
+    kn: ಚಾಥಮ್ ದ್ವೀಪಗಳು
+    ko: 채텀 제도
+    lt: Čatamo salos
+    lv: Četema salas
+    mr: चॅथम आईसलँडस
+    ms: Kepulauan Chatham
+    nb: Chathamøyene
+    nl: Chathameilanden
+    pl: Wyspy Chatham
+    pt: Ilhas Chatham
+    ru: Чатем
+    si: චැතැම් දූපත්
+    sr: Четем острва
+    sv: Chathamöarna
+    ta: சத்தாம் தீவு
+    te: చాతమ్ దీవులు
+    th: หมู่เกาะแชทัม
+    tr: Chatham Adaları
+    uk: Чатем
+    ur: چاتھم آئی لینڈ
+    vi: Quần đảo Chatham
+    ceb: Chatham Islands (rehiyon)
+    sr_Latn: Četem ostrva
+    zh: 查塔姆群岛
+    ccp: "\U00011107\U00011117\U0001111F\U00011134 \U00011103\U00011128\U0001110C\U00011134\U00011123\U00011133\U00011120\U0001111A\U00011133\U00011113\U00011134\U00011125\U00011134"
+    'no': Chathamøyene
+  comments:
 GIS:
   name: Gisborne
   code:
@@ -909,115 +976,4 @@ WTC:
     ccp: "\U00011103\U0001112E\U00011120\U0001112C\U0001110C\U00011134 \U00011107\U0001112E\U0001110C\U00011134\U00011111\U00011134"
     mk: Западно Крајбрежје
     'no': West Coast
-  comments:
-X1~:
-  name: Chatham Islands
-  code:
-  unofficial_names: Chatham Islands
-  geo:
-    latitude: -43.9120964
-    longitude: -176.5433025
-    min_latitude: -44.4343162
-    min_longitude: -176.8940878
-    max_latitude: -43.5631344
-    max_longitude: -175.8314073
-  translations:
-    en: Chatham Islands
-  comments:
-CIT:
-  name:
-  code:
-  unofficial_names:
-  geo:
-    latitude:
-    longitude:
-    min_latitude:
-    min_longitude:
-    max_latitude:
-    max_longitude:
-  translations:
-    ar: جزر تشاتام
-    az: Çatem
-    be: Астравы Чатэм
-    bg: Чатъм
-    bn: চ্যাথাম আইল্যান্ডস
-    ca: Illes Chatham
-    cs: Chathamské ostrovy
-    da: Chatham Øerne
-    de: Chathaminseln
-    el: Νησιά Τσάταμ
-    en: Chatham Islands
-    es: Islas Chatham
-    et: Chathami saared
-    eu: Chatham Islands
-    fa: جزایر چاتام
-    fi: Chathamsaaret
-    fr: Îles Chatham
-    gl: Illas Chatham
-    gu: ચૅથમ આઇલેન્ડ્સ
-    he: איי צ׳טהאם
-    hi: चाथम द्वीपसमूह
-    hr: Chathamski otoci
-    hu: Chatham-szigetek
-    hy: Չաթեմ կղզիներ
-    id: Kepulauan Chatham
-    it: Isole Chatham
-    ja: チャタム諸島
-    ka: ჩატემის კუნძულები
-    kn: ಚಾಥಮ್ ದ್ವೀಪಗಳು
-    ko: 채텀 제도
-    lt: Čatamo salos
-    lv: Četema salas
-    mr: चॅथम आईसलँडस
-    ms: Kepulauan Chatham
-    nb: Chathamøyene
-    nl: Chathameilanden
-    pl: Wyspy Chatham
-    pt: Ilhas Chatham
-    ru: Чатем
-    si: චැතැම් දූපත්
-    sr: Четем острва
-    sv: Chathamöarna
-    ta: சத்தாம் தீவு
-    te: చాతమ్ దీవులు
-    th: หมู่เกาะแชทัม
-    tr: Chatham Adaları
-    uk: Чатем
-    ur: چاتھم آئی لینڈ
-    vi: Quần đảo Chatham
-    ceb: Chatham Islands (rehiyon)
-    sr_Latn: Četem ostrva
-    zh: 查塔姆群岛
-    ccp: "\U00011107\U00011117\U0001111F\U00011134 \U00011103\U00011128\U0001110C\U00011134\U00011123\U00011133\U00011120\U0001111A\U00011133\U00011113\U00011134\U00011125\U00011134"
-    'no': Chathamøyene
-  comments:
-N:
-  name:
-  code:
-  unofficial_names:
-  geo:
-    latitude:
-    longitude:
-    min_latitude:
-    min_longitude:
-    max_latitude:
-    max_longitude:
-  translations:
-    en: North Island
-    ccp: "\U0001111A\U00011127\U00011122\U00011134\U00011112\U00011134 \U00011103\U00011128\U0001110C\U00011134\U00011123\U00011133\U00011120\U0001111A\U00011133\U00011113\U00011134"
-  comments:
-S:
-  name:
-  code:
-  unofficial_names:
-  geo:
-    latitude:
-    longitude:
-    min_latitude:
-    min_longitude:
-    max_latitude:
-    max_longitude:
-  translations:
-    en: South Island
-    ccp: "\U00011125\U00011105\U0001112A\U00011116\U00011134\U00011112\U00011134 \U00011103\U00011128\U0001110C\U00011134\U00011123\U00011133\U00011120\U0001111A\U00011133\U00011113\U00011134"
   comments:


### PR DESCRIPTION
 Remove old N and S subdivisions, remove duplicated Chatham Island entry