### PR TITLE
Bump i18n-data version to 0.14.0

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5'
 
-  gem.add_dependency('i18n_data', '~> 0.13.1')
+  gem.add_dependency('i18n_data', '~> 0.14.0')
   gem.add_dependency('sixarm_ruby_unaccent', '~> 1.1')
   gem.add_development_dependency('rspec', '>= 3')
   gem.add_development_dependency('activesupport', '>= 3')


### PR DESCRIPTION
This PR bumps `i18n-data` gem version to 0.14.0