### PR TITLE
Fix empty translations in LV subdivisions

### DIFF
--- a/lib/countries/data/subdivisions/LV.yaml
+++ b/lib/countries/data/subdivisions/LV.yaml
@@ -2486,6 +2486,8 @@ VEN:
     min_longitude:
     max_latitude:
     max_longitude:
+  translations:
+    lv: Augšdaugavas novads
 '112':
   name: Dienvidkurzemes Novads
   code:
@@ -2497,6 +2499,8 @@ VEN:
     min_longitude:
     max_latitude:
     max_longitude:
+  translations:
+    lv: Dienvidkurzemes Novads
 '113':
   name: Valmieras Novads
   code:
@@ -2508,3 +2512,5 @@ VEN:
     min_longitude:
     max_latitude:
     max_longitude:
+  translations:
+    lv: Valmieras Novads


### PR DESCRIPTION
Ensure LV subdivisions 111, 112 and 113 have a non-empty translation hash. Fixes #718.