### PR TITLE
Remove non-ISO US subdivisions

### DIFF
--- a/lib/countries/data/subdivisions/US.yaml
+++ b/lib/countries/data/subdivisions/US.yaml
@@ -1,32 +1,4 @@
 ---
-AA:
-  name: Armed Forces Americas
-  code:
-  unofficial_names: Armed Forces Americas
-  geo:
-    latitude: 33.8934985
-    longitude: -117.2732567
-    min_latitude: 33.8403275
-    min_longitude: -117.2985014
-    max_latitude: 33.9460679
-    max_longitude: -117.2498013
-  translations:
-    en: Armed Forces Americas
-  comments:
-AE:
-  name: Armed Forces Europe
-  code:
-  unofficial_names: Armed Forces Europe
-  geo:
-    latitude: 59.90441850000001
-    longitude: 10.7408094
-    min_latitude:
-    min_longitude:
-    max_latitude:
-    max_longitude:
-  translations:
-    en: Armed Forces Europe
-  comments:
 AK:
   name: Alaska
   code:
@@ -222,20 +194,6 @@ AL:
     mk: Алабама
     ha_NE: Alabama
     'no': Alabama
-  comments:
-AP:
-  name: Armed Forces Pacific
-  code:
-  unofficial_names: Armed Forces Pacific
-  geo:
-    latitude:
-    longitude:
-    min_latitude:
-    min_longitude:
-    max_latitude:
-    max_longitude:
-  translations:
-    en: Armed Forces Pacific
   comments:
 AR:
   name: Arkansas

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -233,11 +233,11 @@ describe ISO3166::Country do
     end
 
     it 'should return a hash with all sub divisions' do
-      expect(country.subdivisions.size).to eq(60)
+      expect(country.subdivisions.size).to eq(57)
     end
 
     it 'should be available through states' do
-      expect(country.states.size).to eq(60)
+      expect(country.states.size).to eq(57)
     end
 
     it 'should be a subdivision object' do


### PR DESCRIPTION
Remove US subdivisions AA, AE, AP. 

Armed forces subdivisions are USPS codes, but not ISO subdivisions