### PR TITLE
Deprecate `latitude_dec` and `longitude_dec`, delegate to `latitude` …

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -140,14 +140,14 @@ c.states # => {"CO" => {"name" => "Colorado", "names" => "Colorado"}, ... }
 ### Location
 
 ```ruby
-c.latitude # => "38 00 N"
-c.longitude # => "97 00 W"
-c.latitude_dec # => 39.44325637817383
-c.longitude_dec # => -98.95733642578125
+c.latitude # => "37.09024"
+c.longitude # => "-95.712891"
 
 c.region # => "Americas"
 c.subregion # => "Northern America"
 ```
+
+Please note that `latitude_dec` and `longitude_dec` will be deprecated on release 4.2 and deleted in 5.0. These attribues have been redundant for several years, since the `latitude` and `longitude` fields have been switched decimal coordinates.
 
 ### Timezones **(optional)**
 
@@ -180,6 +180,8 @@ c.min_longitude # => '45'
 c.min_latitude # => '22.166667'
 c.max_longitude # => '58'
 c.max_latitude # => '26.133333'
+
+c.bounds #> {"northeast"=>{"lat"=>22.166667, "lng"=>58}, "southwest"=>{"lat"=>26.133333, "lng"=>45}}
 ```
 
 ### European Union Membership

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -32,6 +32,24 @@ module ISO3166
     alias languages languages_official
     alias names unofficial_names
 
+    def latitude_dec
+      if RUBY_VERSION =~ /^3\.\d\.\d/
+        warn "DEPRECATION WARNING: The Country#latitude_dec method has been deprecated and will be removed in 5.0. Please use Country#latitude instead.", uplevel: 1, category: :deprecated
+      else
+        warn "DEPRECATION WARNING: The Country#latitude_dec method has been deprecated and will be removed in 5.0. Please use Country#latitude instead.", uplevel: 1
+      end
+      latitude
+    end
+
+    def longitude_dec
+      if RUBY_VERSION =~ /^3\.\d\.\d/
+        warn "DEPRECATION WARNING: The Country#longitude_dec method has been deprecated and will be removed in 5.0. Please use Country#longitude instead.", uplevel: 1, category: :deprecated
+      else
+        warn "DEPRECATION WARNING: The Country#longitude_dec method has been deprecated and will be removed in 5.0. Please use Country#longitude instead.", uplevel: 1
+      end
+      longitude
+    end
+
     def ==(other)
       other.respond_to?(:alpha2) && other.alpha2 == alpha2
     end

--- a/lib/countries/data/countries/AD.yaml
+++ b/lib/countries/data/countries/AD.yaml
@@ -34,9 +34,7 @@ AD:
   - ca
   geo:
     latitude: 42.506285
-    latitude_dec: '42.5506591796875'
     longitude: 1.521801
-    longitude_dec: '1.5762332677841187'
     max_latitude: 42.655791
     max_longitude: 1.786639
     min_latitude: 42.4287488

--- a/lib/countries/data/countries/AE.yaml
+++ b/lib/countries/data/countries/AE.yaml
@@ -29,8 +29,8 @@ AE:
   vat_rates:
     standard: 5
     reduced: []
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: false
   unofficial_names:
   - United Arab Emirates
@@ -46,9 +46,7 @@ AE:
   - ar
   geo:
     latitude: 23.424076
-    latitude_dec: '23.684776306152344'
     longitude: 53.847818
-    longitude_dec: '54.536643981933594'
     max_latitude: 26.0765
     max_longitude: 56.4395001
     min_latitude: 22.6315138

--- a/lib/countries/data/countries/AF.yaml
+++ b/lib/countries/data/countries/AF.yaml
@@ -36,9 +36,7 @@ AF:
   - tk
   geo:
     latitude: 33.93911
-    latitude_dec: '33.833248138427734'
     longitude: 67.709953
-    longitude_dec: '66.02528381347656'
     max_latitude: 38.49087670000001
     max_longitude: 74.8898619
     min_latitude: 29.3772

--- a/lib/countries/data/countries/AG.yaml
+++ b/lib/countries/data/countries/AG.yaml
@@ -34,9 +34,7 @@ AG:
   - en
   geo:
     latitude: 17.060816
-    latitude_dec: '17.09273910522461'
     longitude: -61.796428
-    longitude_dec: "-61.81040954589844"
     max_latitude: 17.7499946
     max_longitude: -61.6394
     min_latitude: 16.9018

--- a/lib/countries/data/countries/AI.yaml
+++ b/lib/countries/data/countries/AI.yaml
@@ -6,7 +6,7 @@ AI:
   country_code: '1'
   nanp_prefix: '1264'
   international_prefix: '011'
-  ioc: 
+  ioc:
   gec: AV
   name: Anguilla
   national_destination_code_lengths:
@@ -31,9 +31,7 @@ AI:
   - en
   geo:
     latitude: 18.220554
-    latitude_dec: '18.22646713256836'
     longitude: -63.06861499999999
-    longitude_dec: "-63.0473518371582"
     max_latitude: 18.6332326
     max_longitude: -62.91999999999999
     min_latitude: 18.1465043

--- a/lib/countries/data/countries/AL.yaml
+++ b/lib/countries/data/countries/AL.yaml
@@ -35,9 +35,7 @@ AL:
   - sq
   geo:
     latitude: 41.153332
-    latitude_dec: '41.11113357543945'
     longitude: 20.168331
-    longitude_dec: '20.02745246887207'
     max_latitude: 42.6611669
     max_longitude: 21.0572394
     min_latitude: 39.6447296

--- a/lib/countries/data/countries/AM.yaml
+++ b/lib/countries/data/countries/AM.yaml
@@ -35,9 +35,7 @@ AM:
   - ru
   geo:
     latitude: 40.069099
-    latitude_dec: '40.29266357421875'
     longitude: 45.038189
-    longitude_dec: '44.93947219848633'
     max_latitude: 41.300993
     max_longitude: 46.6342219
     min_latitude: 38.840244

--- a/lib/countries/data/countries/AO.yaml
+++ b/lib/countries/data/countries/AO.yaml
@@ -29,9 +29,7 @@ AO:
   - pt
   geo:
     latitude: -11.202692
-    latitude_dec: "-12.333555221557617"
     longitude: 17.873887
-    longitude_dec: '17.539464950561523'
     max_latitude: -4.388063300000001
     max_longitude: 24.0878855
     min_latitude: -18.0391039

--- a/lib/countries/data/countries/AQ.yaml
+++ b/lib/countries/data/countries/AQ.yaml
@@ -5,7 +5,7 @@ AQ:
   alpha3: ATA
   country_code: '672'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: AY
   name: Antarctica
   national_destination_code_lengths: []
@@ -28,9 +28,7 @@ AQ:
   languages_spoken: []
   geo:
     latitude: -82.862752
-    latitude_dec: "-82.862752"
     longitude: 135
-    longitude_dec: "-135.0"
     max_latitude: -60.1086999
     max_longitude: 180
     min_latitude: -90

--- a/lib/countries/data/countries/AR.yaml
+++ b/lib/countries/data/countries/AR.yaml
@@ -42,9 +42,7 @@ AR:
   - gn
   geo:
     latitude: -38.416097
-    latitude_dec: "-37.071964263916016"
     longitude: -63.61667199999999
-    longitude_dec: "-64.85450744628906"
     max_latitude: -21.7810459
     max_longitude: -53.637481
     min_latitude: -55.1250224

--- a/lib/countries/data/countries/AS.yaml
+++ b/lib/countries/data/countries/AS.yaml
@@ -37,9 +37,7 @@ AS:
   - sm
   geo:
     latitude: -14.270972
-    latitude_dec: "-14.31956672668457"
     longitude: -170.132217
-    longitude_dec: "-170.7403564453125"
     max_latitude: -13.4056506
     max_longitude: -169.2059326
     min_latitude: -14.7217608

--- a/lib/countries/data/countries/AT.yaml
+++ b/lib/countries/data/countries/AT.yaml
@@ -54,9 +54,7 @@ AT:
   - de
   geo:
     latitude: 47.516231
-    latitude_dec: '47.58843994140625'
     longitude: 14.550072
-    longitude_dec: '14.14021110534668'
     max_latitude: 49.0206081
     max_longitude: 17.1607329
     min_latitude: 46.37233579999999

--- a/lib/countries/data/countries/AU.yaml
+++ b/lib/countries/data/countries/AU.yaml
@@ -27,8 +27,8 @@ AU:
   vat_rates:
     standard: 10
     reduced: []
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:
@@ -43,9 +43,7 @@ AU:
   - en
   geo:
     latitude: -25.274398
-    latitude_dec: "-25.585241317749023"
     longitude: 133.775136
-    longitude_dec: '134.50411987304688'
     max_latitude: -9.187026399999999
     max_longitude: 159.2872223
     min_latitude: -54.83376579999999

--- a/lib/countries/data/countries/AW.yaml
+++ b/lib/countries/data/countries/AW.yaml
@@ -29,9 +29,7 @@ AW:
   - nl
   geo:
     latitude: 12.52111
-    latitude_dec: '12.506523132324219'
     longitude: -69.968338
-    longitude_dec: "-69.96931457519531"
     max_latitude: 12.6306179
     max_longitude: -69.8644638
     min_latitude: 12.406093

--- a/lib/countries/data/countries/AX.yaml
+++ b/lib/countries/data/countries/AX.yaml
@@ -5,8 +5,8 @@ AX:
   alpha3: ALA
   country_code: '358'
   international_prefix: ''
-  ioc: 
-  gec: 
+  ioc:
+  gec:
   name: Åland Islands
   national_destination_code_lengths: []
   national_number_lengths: []
@@ -30,9 +30,7 @@ AX:
   - sv
   geo:
     latitude: 60.1785247
-    latitude_dec: '60.2023811340332'
     longitude: 19.9156105
-    longitude_dec: '19.96520233154297'
     max_latitude: 60.8400009
     max_longitude: 21.4866841
     min_latitude: 59.6872001

--- a/lib/countries/data/countries/AZ.yaml
+++ b/lib/countries/data/countries/AZ.yaml
@@ -37,9 +37,7 @@ AZ:
   - hy
   geo:
     latitude: 40.143105
-    latitude_dec: '40.33100509643555'
     longitude: 47.576927
-    longitude_dec: '47.80820083618164'
     max_latitude: 41.9594999
     max_longitude: 50.7458001
     min_latitude: 38.3922171

--- a/lib/countries/data/countries/BA.yaml
+++ b/lib/countries/data/countries/BA.yaml
@@ -44,9 +44,7 @@ BA:
   - sr
   geo:
     latitude: 43.915886
-    latitude_dec: '44.16533279418945'
     longitude: 17.679076
-    longitude_dec: '17.790241241455078'
     max_latitude: 45.2766262
     max_longitude: 19.6237016
     min_latitude: 42.5564808

--- a/lib/countries/data/countries/BB.yaml
+++ b/lib/countries/data/countries/BB.yaml
@@ -32,9 +32,7 @@ BB:
   - en
   geo:
     latitude: 13.193887
-    latitude_dec: '13.178098678588867'
     longitude: -59.543198
-    longitude_dec: "-59.5485954284668"
     max_latitude: 13.3365093
     max_longitude: -59.4174957
     min_latitude: 13.039844

--- a/lib/countries/data/countries/BD.yaml
+++ b/lib/countries/data/countries/BD.yaml
@@ -31,9 +31,7 @@ BD:
   - bn
   geo:
     latitude: 23.684994
-    latitude_dec: '23.730104446411133'
     longitude: 90.356331
-    longitude_dec: '90.30652618408203'
     max_latitude: 26.633914
     max_longitude: 92.6801153
     min_latitude: 20.3794

--- a/lib/countries/data/countries/BE.yaml
+++ b/lib/countries/data/countries/BE.yaml
@@ -53,9 +53,7 @@ BE:
   - de
   geo:
     latitude: 50.503887
-    latitude_dec: '50.648963928222656'
     longitude: 4.469936
-    longitude_dec: '4.641502380371094'
     max_latitude: 51.5051449
     max_longitude: 6.408124099999999
     min_latitude: 49.497013

--- a/lib/countries/data/countries/BF.yaml
+++ b/lib/countries/data/countries/BF.yaml
@@ -31,9 +31,7 @@ BF:
   - ff
   geo:
     latitude: 12.238333
-    latitude_dec: '12.284985542297363'
     longitude: -1.561593
-    longitude_dec: "-1.745560646057129"
     max_latitude: 15.0840397
     max_longitude: 2.4043596
     min_latitude: 9.4104717

--- a/lib/countries/data/countries/BG.yaml
+++ b/lib/countries/data/countries/BG.yaml
@@ -48,9 +48,7 @@ BG:
   - bg
   geo:
     latitude: 42.733883
-    latitude_dec: '42.7661018371582'
     longitude: 25.48583
-    longitude_dec: '25.283733367919922'
     max_latitude: 44.2153059
     max_longitude: 28.7292001
     min_latitude: 41.2354469

--- a/lib/countries/data/countries/BH.yaml
+++ b/lib/countries/data/countries/BH.yaml
@@ -38,9 +38,7 @@ BH:
   - ar
   geo:
     latitude: 26.0667
-    latitude_dec: '26.094240188598633'
     longitude: 50.5577
-    longitude_dec: '50.54299545288086'
     max_latitude: 26.3469001
     max_longitude: 50.8509064
     min_latitude: 25.5349999

--- a/lib/countries/data/countries/BI.yaml
+++ b/lib/countries/data/countries/BI.yaml
@@ -31,9 +31,7 @@ BI:
   - rn
   geo:
     latitude: -3.373056
-    latitude_dec: "-3.365208148956299"
     longitude: 29.918886
-    longitude_dec: '29.88650894165039'
     max_latitude: -2.3097301
     max_longitude: 30.84954
     min_latitude: -4.4693288

--- a/lib/countries/data/countries/BJ.yaml
+++ b/lib/countries/data/countries/BJ.yaml
@@ -30,9 +30,7 @@ BJ:
   - fr
   geo:
     latitude: 9.30769
-    latitude_dec: '9.624112129211426'
     longitude: 2.315834
-    longitude_dec: '2.3377387523651123'
     max_latitude: 12.4086111
     max_longitude: 3.8433429
     min_latitude: 6.2061001

--- a/lib/countries/data/countries/BL.yaml
+++ b/lib/countries/data/countries/BL.yaml
@@ -5,7 +5,7 @@ BL:
   alpha3: BLM
   country_code: '590'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: TB
   name: Saint Barthélemy
   national_destination_code_lengths: []
@@ -29,9 +29,7 @@ BL:
   - fr
   geo:
     latitude: 17.9
-    latitude_dec: '17.89626121520996'
     longitude: -62.833333
-    longitude_dec: "-62.83061218261719"
     max_latitude: 17.978
     max_longitude: -62.7869
     min_latitude: 17.8663

--- a/lib/countries/data/countries/BM.yaml
+++ b/lib/countries/data/countries/BM.yaml
@@ -33,9 +33,7 @@ BM:
   - en
   geo:
     latitude: 32.3078
-    latitude_dec: '32.302669525146484'
     longitude: -64.7505
-    longitude_dec: "-64.7516860961914"
     max_latitude: 32.3961
     max_longitude: -64.6413999
     min_latitude: 32.2424975

--- a/lib/countries/data/countries/BN.yaml
+++ b/lib/countries/data/countries/BN.yaml
@@ -30,9 +30,7 @@ BN:
   - ms
   geo:
     latitude: 4.535277
-    latitude_dec: '4.5703840255737305'
     longitude: 114.727669
-    longitude_dec: '114.74818420410156'
     max_latitude: 5.0978001
     max_longitude: 115.3639552
     min_latitude: 4.002460999999999

--- a/lib/countries/data/countries/BO.yaml
+++ b/lib/countries/data/countries/BO.yaml
@@ -35,9 +35,7 @@ BO:
   - qu
   geo:
     latitude: -16.290154
-    latitude_dec: "-16.713054656982422"
     longitude: -63.58865299999999
-    longitude_dec: "-64.6666488647461"
     max_latitude: -9.669323
     max_longitude: -57.453803
     min_latitude: -22.8980899

--- a/lib/countries/data/countries/BQ.yaml
+++ b/lib/countries/data/countries/BQ.yaml
@@ -31,9 +31,7 @@ BQ:
   - en
   geo:
     latitude: 12.1783611
-    latitude_dec: '12.178361'
     longitude: -68.2385339
-    longitude_dec: "-68.238534"
     max_latitude: 17.6606999
     max_longitude: -62.9228
     min_latitude: 11.9641

--- a/lib/countries/data/countries/BR.yaml
+++ b/lib/countries/data/countries/BR.yaml
@@ -30,8 +30,8 @@ BR:
     reduced:
     - 12
     - 7
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}-?\\d{3}"
   unofficial_names:
@@ -47,9 +47,7 @@ BR:
   - pt
   geo:
     latitude: -14.235004
-    latitude_dec: "-10.81045150756836"
     longitude: -51.92528
-    longitude_dec: "-52.97311782836914"
     max_latitude: 5.2717863
     max_longitude: -28.650543
     min_latitude: -34.0891

--- a/lib/countries/data/countries/BS.yaml
+++ b/lib/countries/data/countries/BS.yaml
@@ -31,9 +31,7 @@ BS:
   - en
   geo:
     latitude: 25.03428
-    latitude_dec: '25.035648345947266'
     longitude: -77.39627999999999
-    longitude_dec: "-77.39512634277344"
     max_latitude: 27.263412
     max_longitude: -72.70975390000001
     min_latitude: 20.9082735

--- a/lib/countries/data/countries/BT.yaml
+++ b/lib/countries/data/countries/BT.yaml
@@ -33,9 +33,7 @@ BT:
   - dz
   geo:
     latitude: 27.514162
-    latitude_dec: '27.416879653930664'
     longitude: 90.433601
-    longitude_dec: '90.43476104736328'
     max_latitude: 28.246987
     max_longitude: 92.125232
     min_latitude: 26.702016

--- a/lib/countries/data/countries/BV.yaml
+++ b/lib/countries/data/countries/BV.yaml
@@ -5,7 +5,7 @@ BV:
   alpha3: BVT
   country_code: '47'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: BV
   name: Bouvet Island
   national_destination_code_lengths: []
@@ -27,9 +27,7 @@ BV:
   languages_spoken: []
   geo:
     latitude: -54.4207915
-    latitude_dec: "-54.4342041015625"
     longitude: 3.3464497
-    longitude_dec: '3.4102511405944824'
     max_latitude: -54.3869298
     max_longitude: 3.4332785
     min_latitude: -54.4541004

--- a/lib/countries/data/countries/BW.yaml
+++ b/lib/countries/data/countries/BW.yaml
@@ -31,9 +31,7 @@ BW:
   - tn
   geo:
     latitude: -22.328474
-    latitude_dec: "-22.186752319335938"
     longitude: 24.684866
-    longitude_dec: '23.81494140625'
     max_latitude: -17.7781369
     max_longitude: 29.375304
     min_latitude: -26.9075448

--- a/lib/countries/data/countries/BY.yaml
+++ b/lib/countries/data/countries/BY.yaml
@@ -37,9 +37,7 @@ BY:
   - ru
   geo:
     latitude: 53.709807
-    latitude_dec: '53.54347229003906'
     longitude: 27.953389
-    longitude_dec: '28.054094314575195'
     max_latitude: 56.1718719
     max_longitude: 32.7768202
     min_latitude: 51.26201100000001

--- a/lib/countries/data/countries/BZ.yaml
+++ b/lib/countries/data/countries/BZ.yaml
@@ -32,9 +32,7 @@ BZ:
   - es
   geo:
     latitude: 17.189877
-    latitude_dec: '17.225292205810547'
     longitude: -88.49765
-    longitude_dec: "-88.66973876953125"
     max_latitude: 18.4959419
     max_longitude: -87.41269989999999
     min_latitude: 15.8856189

--- a/lib/countries/data/countries/CA.yaml
+++ b/lib/countries/data/countries/CA.yaml
@@ -39,9 +39,7 @@ CA:
   - fr
   geo:
     latitude: 56.130366
-    latitude_dec: '62.832908630371094'
     longitude: -106.346771
-    longitude_dec: "-95.91332244873047"
     max_latitude: 83.6381
     max_longitude: -50.9766
     min_latitude: 41.6765559

--- a/lib/countries/data/countries/CC.yaml
+++ b/lib/countries/data/countries/CC.yaml
@@ -5,7 +5,7 @@ CC:
   alpha3: CCK
   country_code: '61'
   international_prefix: '0011'
-  ioc: 
+  ioc:
   gec: CK
   name: Cocos (Keeling) Islands
   national_destination_code_lengths:
@@ -32,9 +32,7 @@ CC:
   - en
   geo:
     latitude: -12.164165
-    latitude_dec: "-12.200602531433105"
     longitude: 96.87095599999999
-    longitude_dec: '96.85894012451172'
     max_latitude: -11.819973
     max_longitude: 96.93271639999999
     min_latitude: -12.2118513

--- a/lib/countries/data/countries/CD.yaml
+++ b/lib/countries/data/countries/CD.yaml
@@ -43,9 +43,7 @@ CD:
   - lu
   geo:
     latitude: -4.038333
-    latitude_dec: "-2.879866123199463"
     longitude: 21.758664
-    longitude_dec: '23.6563777923584'
     max_latitude: 5.3920029
     max_longitude: 31.314612
     min_latitude: -13.4590349

--- a/lib/countries/data/countries/CF.yaml
+++ b/lib/countries/data/countries/CF.yaml
@@ -35,9 +35,7 @@ CF:
   - sg
   geo:
     latitude: 6.611110999999999
-    latitude_dec: '6.574123382568359'
     longitude: 20.939444
-    longitude_dec: '20.486923217773438'
     max_latitude: 11.0179569
     max_longitude: 27.4583049
     min_latitude: 2.2230529

--- a/lib/countries/data/countries/CG.yaml
+++ b/lib/countries/data/countries/CG.yaml
@@ -34,9 +34,7 @@ CG:
   - ln
   geo:
     latitude: -0.228021
-    latitude_dec: "-2.879866123199463"
     longitude: 15.827659
-    longitude_dec: '23.6563777923584'
     max_latitude: 3.707791
     max_longitude: 18.650421
     min_latitude: -5.0964

--- a/lib/countries/data/countries/CH.yaml
+++ b/lib/countries/data/countries/CH.yaml
@@ -52,9 +52,7 @@ CH:
   - it
   geo:
     latitude: 46.818188
-    latitude_dec: '46.80379867553711'
     longitude: 8.227511999999999
-    longitude_dec: '8.222854614257812'
     max_latitude: 47.8084546
     max_longitude: 10.4923401
     min_latitude: 45.81792

--- a/lib/countries/data/countries/CI.yaml
+++ b/lib/countries/data/countries/CI.yaml
@@ -34,9 +34,7 @@ CI:
   - fr
   geo:
     latitude: 7.539988999999999
-    latitude_dec: '7.598755359649658'
     longitude: -5.547079999999999
-    longitude_dec: "-5.552574634552002"
     max_latitude: 10.7400149
     max_longitude: -2.493031
     min_latitude: 4.193

--- a/lib/countries/data/countries/CK.yaml
+++ b/lib/countries/data/countries/CK.yaml
@@ -33,9 +33,7 @@ CK:
   - en
   geo:
     latitude: -21.236736
-    latitude_dec: "-21.22330665588379"
     longitude: -159.777671
-    longitude_dec: "-159.7405548095703"
     max_latitude: -8.1679932
     max_longitude: -155.6982422
     min_latitude: -23.0898384

--- a/lib/countries/data/countries/CL.yaml
+++ b/lib/countries/data/countries/CL.yaml
@@ -37,9 +37,7 @@ CL:
   - es
   geo:
     latitude: -35.675147
-    latitude_dec: "-35.78622817993164"
     longitude: -71.542969
-    longitude_dec: "-71.67467498779297"
     max_latitude: -17.4983291
     max_longitude: -66.3327
     min_latitude: -56.1455

--- a/lib/countries/data/countries/CM.yaml
+++ b/lib/countries/data/countries/CM.yaml
@@ -35,9 +35,7 @@ CM:
   - fr
   geo:
     latitude: 7.369721999999999
-    latitude_dec: '5.685476779937744'
     longitude: 12.354722
-    longitude_dec: '12.722877502441406'
     max_latitude: 13.083335
     max_longitude: 16.1944081
     min_latitude: 1.6559

--- a/lib/countries/data/countries/CN.yaml
+++ b/lib/countries/data/countries/CN.yaml
@@ -40,9 +40,7 @@ CN:
   - zh
   geo:
     latitude: 35.86166
-    latitude_dec: '36.55308532714844'
     longitude: 104.195397
-    longitude_dec: '103.97543334960938'
     max_latitude: 53.5609739
     max_longitude: 134.7754563
     min_latitude: 17.9996

--- a/lib/countries/data/countries/CO.yaml
+++ b/lib/countries/data/countries/CO.yaml
@@ -33,9 +33,7 @@ CO:
   - es
   geo:
     latitude: 4.570868
-    latitude_dec: '3.9976072311401367'
     longitude: -74.297333
-    longitude_dec: "-73.27796936035156"
     max_latitude: 13.5177999
     max_longitude: -66.8463122
     min_latitude: -4.227109899999999

--- a/lib/countries/data/countries/CR.yaml
+++ b/lib/countries/data/countries/CR.yaml
@@ -30,9 +30,7 @@ CR:
   - es
   geo:
     latitude: 9.748916999999999
-    latitude_dec: '9.884991645812988'
     longitude: -83.753428
-    longitude_dec: "-84.22723388671875"
     max_latitude: 11.2196806
     max_longitude: -82.51830009999999
     min_latitude: 5.496099999999999

--- a/lib/countries/data/countries/CU.yaml
+++ b/lib/countries/data/countries/CU.yaml
@@ -31,9 +31,7 @@ CU:
   - es
   geo:
     latitude: 21.521757
-    latitude_dec: '22.066335678100586'
     longitude: -77.781167
-    longitude_dec: "-79.4531478881836"
     max_latitude: 23.3776001
     max_longitude: -73.9545
     min_latitude: 19.6529001

--- a/lib/countries/data/countries/CV.yaml
+++ b/lib/countries/data/countries/CV.yaml
@@ -34,9 +34,7 @@ CV:
   - pt
   geo:
     latitude: 16.5388
-    latitude_dec: '15.183002471923828'
     longitude: -23.0418
-    longitude_dec: "-23.70345115661621"
     max_latitude: 17.3191764
     max_longitude: -22.5933839
     min_latitude: 14.7270733

--- a/lib/countries/data/countries/CW.yaml
+++ b/lib/countries/data/countries/CW.yaml
@@ -5,7 +5,7 @@ CW:
   alpha3: CUW
   country_code: '599'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: UC
   name: Curaçao
   national_destination_code_lengths:
@@ -29,9 +29,7 @@ CW:
   - nl
   geo:
     latitude: 12.16957
-    latitude_dec: '12.163220405578613'
     longitude: -68.99002
-    longitude_dec: "-68.94505310058594"
     max_latitude: 12.4941999
     max_longitude: -68.5670001
     min_latitude: 11.9224

--- a/lib/countries/data/countries/CX.yaml
+++ b/lib/countries/data/countries/CX.yaml
@@ -5,7 +5,7 @@ CX:
   alpha3: CXR
   country_code: '61'
   international_prefix: '0011'
-  ioc: 
+  ioc:
   gec: KT
   name: Christmas Island
   national_destination_code_lengths: []
@@ -34,9 +34,7 @@ CX:
   - ms
   geo:
     latitude: -10.447525
-    latitude_dec: "-10.490290641784668"
     longitude: 105.690449
-    longitude_dec: '105.63275146484375'
     max_latitude: -10.412352
     max_longitude: 105.7129382
     min_latitude: -10.5703619

--- a/lib/countries/data/countries/CY.yaml
+++ b/lib/countries/data/countries/CY.yaml
@@ -46,9 +46,7 @@ CY:
   - hy
   geo:
     latitude: 35.126413
-    latitude_dec: '35.11473846435547'
     longitude: 33.429859
-    longitude_dec: '33.486717224121094'
     max_latitude: 35.7071999
     max_longitude: 34.60450000000001
     min_latitude: 34.6304001

--- a/lib/countries/data/countries/CZ.yaml
+++ b/lib/countries/data/countries/CZ.yaml
@@ -50,9 +50,7 @@ CZ:
   - sk
   geo:
     latitude: 49.81749199999999
-    latitude_dec: '49.739105224609375'
     longitude: 15.472962
-    longitude_dec: '15.331501007080078'
     max_latitude: 51.0557185
     max_longitude: 18.8592361
     min_latitude: 48.5518081

--- a/lib/countries/data/countries/DE.yaml
+++ b/lib/countries/data/countries/DE.yaml
@@ -55,9 +55,7 @@ DE:
   - de
   geo:
     latitude: 51.165691
-    latitude_dec: '51.20246505737305'
     longitude: 10.451526
-    longitude_dec: '10.382203102111816'
     max_latitude: 55.0815
     max_longitude: 15.0418962
     min_latitude: 47.2701115

--- a/lib/countries/data/countries/DJ.yaml
+++ b/lib/countries/data/countries/DJ.yaml
@@ -33,9 +33,7 @@ DJ:
   - fr
   geo:
     latitude: 11.825138
-    latitude_dec: '11.742591857910156'
     longitude: 42.590275
-    longitude_dec: '42.63182830810547'
     max_latitude: 12.7136972
     max_longitude: 43.4839
     min_latitude: 10.912953

--- a/lib/countries/data/countries/DK.yaml
+++ b/lib/countries/data/countries/DK.yaml
@@ -47,9 +47,7 @@ DK:
   - da
   geo:
     latitude: 56.26392
-    latitude_dec: '56.10176086425781'
     longitude: 9.501785
-    longitude_dec: '9.555907249450684'
     max_latitude: 58.02846
     max_longitude: 15.2298
     min_latitude: 54.4317001

--- a/lib/countries/data/countries/DM.yaml
+++ b/lib/countries/data/countries/DM.yaml
@@ -30,9 +30,7 @@ DM:
   - en
   geo:
     latitude: 15.414999
-    latitude_dec: '15.3991060256958'
     longitude: -61.37097600000001
-    longitude_dec: "-61.33945846557617"
     max_latitude: 15.6485199
     max_longitude: -61.23090180000001
     min_latitude: 15.2042266

--- a/lib/countries/data/countries/DO.yaml
+++ b/lib/countries/data/countries/DO.yaml
@@ -34,9 +34,7 @@ DO:
   - es
   geo:
     latitude: 18.735693
-    latitude_dec: '19.019824981689453'
     longitude: -70.162651
-    longitude_dec: "-70.79285430908203"
     max_latitude: 19.9786989
     max_longitude: -68.25260010000001
     min_latitude: 17.3611001

--- a/lib/countries/data/countries/DZ.yaml
+++ b/lib/countries/data/countries/DZ.yaml
@@ -35,9 +35,7 @@ DZ:
   - ar
   geo:
     latitude: 28.033886
-    latitude_dec: '28.213645935058594'
     longitude: 1.659626
-    longitude_dec: '2.6547281742095947'
     max_latitude: 37.2216
     max_longitude: 11.9999992
     min_latitude: 18.9681469

--- a/lib/countries/data/countries/EC.yaml
+++ b/lib/countries/data/countries/EC.yaml
@@ -32,9 +32,7 @@ EC:
   - es
   geo:
     latitude: -1.831239
-    latitude_dec: "-1.421528935432434"
     longitude: -78.18340599999999
-    longitude_dec: "-78.87104034423828"
     max_latitude: 2.2955
     max_longitude: -75.1887938
     min_latitude: -5.0143509

--- a/lib/countries/data/countries/EE.yaml
+++ b/lib/countries/data/countries/EE.yaml
@@ -41,9 +41,7 @@ EE:
   - et
   geo:
     latitude: 58.595272
-    latitude_dec: '58.69374465942383'
     longitude: 25.0136071
-    longitude_dec: '25.24162483215332'
     max_latitude: 59.7315
     max_longitude: 28.2101389
     min_latitude: 57.50931600000001

--- a/lib/countries/data/countries/EG.yaml
+++ b/lib/countries/data/countries/EG.yaml
@@ -40,9 +40,7 @@ EG:
   - ar
   geo:
     latitude: 26.820553
-    latitude_dec: '26.756103515625'
     longitude: 30.802498
-    longitude_dec: '29.86229705810547'
     max_latitude: 31.8122
     max_longitude: 37.0569
     min_latitude: 21.9999999

--- a/lib/countries/data/countries/EH.yaml
+++ b/lib/countries/data/countries/EH.yaml
@@ -5,7 +5,7 @@ EH:
   alpha3: ESH
   country_code: '212'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: WI
   name: Western Sahara
   national_destination_code_lengths: []
@@ -34,9 +34,7 @@ EH:
   - fr
   geo:
     latitude: 24.215527
-    latitude_dec: '25'
     longitude: -12.885834
-    longitude_dec: "-13"
     max_latitude: 27.7223999
     max_longitude: -8.667525
     min_latitude: 20.427

--- a/lib/countries/data/countries/ER.yaml
+++ b/lib/countries/data/countries/ER.yaml
@@ -35,9 +35,7 @@ ER:
   - ti
   geo:
     latitude: 15.179384
-    latitude_dec: '15.397199630737305'
     longitude: 39.782334
-    longitude_dec: '39.087188720703125'
     max_latitude: 18.0204137
     max_longitude: 43.2312
     min_latitude: 12.354723

--- a/lib/countries/data/countries/ES.yaml
+++ b/lib/countries/data/countries/ES.yaml
@@ -48,9 +48,7 @@ ES:
   - es
   geo:
     latitude: 40.46366700000001
-    latitude_dec: '40.396026611328125'
     longitude: -3.74922
-    longitude_dec: "-3.550692558288574"
     max_latitude: 43.8504
     max_longitude: 4.6362
     min_latitude: 27.4985

--- a/lib/countries/data/countries/ET.yaml
+++ b/lib/countries/data/countries/ET.yaml
@@ -34,9 +34,7 @@ ET:
   - am
   geo:
     latitude: 9.145000000000001
-    latitude_dec: '8.626703262329102'
     longitude: 40.489673
-    longitude_dec: '39.63755416870117'
     max_latitude: 14.8942141
     max_longitude: 48.0010561
     min_latitude: 3.4041369

--- a/lib/countries/data/countries/FI.yaml
+++ b/lib/countries/data/countries/FI.yaml
@@ -49,9 +49,7 @@ FI:
   - sv
   geo:
     latitude: 61.92410999999999
-    latitude_dec: '64.28858184814453'
     longitude: 25.7481511
-    longitude_dec: '25.989402770996094'
     max_latitude: 70.0922932
     max_longitude: 31.5870999
     min_latitude: 59.693623

--- a/lib/countries/data/countries/FJ.yaml
+++ b/lib/countries/data/countries/FJ.yaml
@@ -37,9 +37,7 @@ FJ:
   - ur
   geo:
     latitude: -17.713371
-    latitude_dec: "-17.658161163330078"
     longitude: 178.065032
-    longitude_dec: '178.1472625732422'
     max_latitude: -12.2084957
     max_longitude: -177.8686523
     min_latitude: -20.8998713

--- a/lib/countries/data/countries/FK.yaml
+++ b/lib/countries/data/countries/FK.yaml
@@ -5,7 +5,7 @@ FK:
   alpha3: FLK
   country_code: '500'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: FK
   name: Falkland Islands (Malvinas)
   national_destination_code_lengths:
@@ -34,9 +34,7 @@ FK:
   - en
   geo:
     latitude: -51.796253
-    latitude_dec: "-51.77312469482422"
     longitude: -59.523613
-    longitude_dec: "-59.727909088134766"
     max_latitude: -50.9809115
     max_longitude: -57.6768495
     min_latitude: -52.4744161

--- a/lib/countries/data/countries/FM.yaml
+++ b/lib/countries/data/countries/FM.yaml
@@ -33,9 +33,7 @@ FM:
   - en
   geo:
     latitude: 7.425554
-    latitude_dec: '6.869349002838135'
     longitude: 150.550812
-    longitude_dec: '158.187255859375'
     max_latitude: 10.2770863
     max_longitude: 163.5177612
     min_latitude: 0.1538084

--- a/lib/countries/data/countries/FO.yaml
+++ b/lib/countries/data/countries/FO.yaml
@@ -34,9 +34,7 @@ FO:
   - fo
   geo:
     latitude: 61.89263500000001
-    latitude_dec: '62.009559631347656'
     longitude: -6.9118061
-    longitude_dec: "-6.818255424499512"
     max_latitude: 62.4310742
     max_longitude: -6.190796
     min_latitude: 61.3677776

--- a/lib/countries/data/countries/FR.yaml
+++ b/lib/countries/data/countries/FR.yaml
@@ -49,9 +49,7 @@ FR:
   - fr
   geo:
     latitude: 46.227638
-    latitude_dec: '46.63727951049805'
     longitude: 2.213749
-    longitude_dec: '2.3382623195648193'
     max_latitude: 51.1241999
     max_longitude: 9.6624999
     min_latitude: 41.31433

--- a/lib/countries/data/countries/GA.yaml
+++ b/lib/countries/data/countries/GA.yaml
@@ -33,9 +33,7 @@ GA:
   - fr
   geo:
     latitude: -0.803689
-    latitude_dec: "-0.6345400810241699"
     longitude: 11.609444
-    longitude_dec: '11.738608360290527'
     max_latitude: 2.318109
     max_longitude: 14.5269234
     min_latitude: -4.1656

--- a/lib/countries/data/countries/GB.yaml
+++ b/lib/countries/data/countries/GB.yaml
@@ -33,8 +33,8 @@ GB:
     standard: 20
     reduced:
     - 5
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: GIR ?0AA|(?:(?:AB|AL|B|BA|BB|BD|BF|BH|BL|BN|BR|BS|BT|BX|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(?:\d[\dA-Z]?
     ?\d[ABD-HJLN-UW-Z]{2}))|BFPO ?\d{1,4}
@@ -55,19 +55,17 @@ GB:
   - en
   geo:
     latitude: 55.378051
-    latitude_dec: '54.56088638305664'
     longitude: -3.435973
-    longitude_dec: "-2.2125117778778076"
     max_latitude: 60.91569999999999
-    max_longitude: 33.9165549
-    min_latitude: 34.5614
-    min_longitude: -8.8988999
+    max_longitude: 1.68153079591
+    min_latitude: 49.959999905
+    min_longitude: -7.57216793459
     bounds:
       northeast:
         lat: 60.91569999999999
-        lng: 33.9165549
+        lng: 1.68153079591
       southwest:
-        lat: 34.5614
-        lng: -8.8988999
+        lat: 49.959999905
+        lng: -7.57216793459
   currency_code: GBP
   start_of_week: monday

--- a/lib/countries/data/countries/GD.yaml
+++ b/lib/countries/data/countries/GD.yaml
@@ -30,9 +30,7 @@ GD:
   - en
   geo:
     latitude: 12.1165
-    latitude_dec: '12.178866386413574'
     longitude: -61.67899999999999
-    longitude_dec: "-61.64693069458008"
     max_latitude: 12.5367
     max_longitude: -61.3746999
     min_latitude: 11.9829051

--- a/lib/countries/data/countries/GE.yaml
+++ b/lib/countries/data/countries/GE.yaml
@@ -33,9 +33,7 @@ GE:
   - ka
   geo:
     latitude: 42.315407
-    latitude_dec: '42.3207845'
     longitude: 43.35689199999999
-    longitude_dec: '43.3713615'
     max_latitude: 43.5866269
     max_longitude: 46.7361189
     min_latitude: 41.054942

--- a/lib/countries/data/countries/GF.yaml
+++ b/lib/countries/data/countries/GF.yaml
@@ -5,7 +5,7 @@ GF:
   alpha3: GUF
   country_code: '594'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: FG
   name: French Guiana
   national_destination_code_lengths:
@@ -33,9 +33,7 @@ GF:
   - fr
   geo:
     latitude: 3.933889
-    latitude_dec: '4.069991111755371'
     longitude: -53.125782
-    longitude_dec: "-53.16830825805664"
     max_latitude: 5.9548
     max_longitude: -51.6164491
     min_latitude: 2.109287

--- a/lib/countries/data/countries/GG.yaml
+++ b/lib/countries/data/countries/GG.yaml
@@ -5,7 +5,7 @@ GG:
   alpha3: GGY
   country_code: '44'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: GK
   name: Guernsey
   national_destination_code_lengths: []
@@ -34,9 +34,7 @@ GG:
   - fr
   geo:
     latitude: 49.4481982
-    latitude_dec: '49.72008514404297'
     longitude: -2.58949
-    longitude_dec: "-2.1999685764312744"
     max_latitude: 49.5094108
     max_longitude: -2.5016885
     min_latitude: 49.4167199

--- a/lib/countries/data/countries/GH.yaml
+++ b/lib/countries/data/countries/GH.yaml
@@ -32,9 +32,7 @@ GH:
   - en
   geo:
     latitude: 7.946527
-    latitude_dec: '7.921330451965332'
     longitude: -1.023194
-    longitude_dec: "-1.2043862342834473"
     max_latitude: 11.1750308
     max_longitude: 1.199972
     min_latitude: 4.6339001

--- a/lib/countries/data/countries/GI.yaml
+++ b/lib/countries/data/countries/GI.yaml
@@ -5,7 +5,7 @@ GI:
   alpha3: GIB
   country_code: '350'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: GI
   name: Gibraltar
   national_destination_code_lengths:
@@ -30,9 +30,7 @@ GI:
   - en
   geo:
     latitude: 36.140751
-    latitude_dec: '36.135841369628906'
     longitude: -5.353585
-    longitude_dec: "-5.349248886108398"
     max_latitude: 36.1551186
     max_longitude: -5.334499999999999
     min_latitude: 36.1038999

--- a/lib/countries/data/countries/GL.yaml
+++ b/lib/countries/data/countries/GL.yaml
@@ -10,7 +10,7 @@ GL:
   alpha3: GRL
   country_code: '299'
   international_prefix: '009'
-  ioc: 
+  ioc:
   gec: GL
   name: Greenland
   national_destination_code_lengths:
@@ -38,9 +38,7 @@ GL:
   - kl
   geo:
     latitude: 71.706936
-    latitude_dec: '74.34954833984375'
     longitude: -42.604303
-    longitude_dec: "-41.08988952636719"
     max_latitude: 83.9702561
     max_longitude: -8.2617199
     min_latitude: 58.26329

--- a/lib/countries/data/countries/GM.yaml
+++ b/lib/countries/data/countries/GM.yaml
@@ -29,9 +29,7 @@ GM:
   - en
   geo:
     latitude: 13.443182
-    latitude_dec: '13.440265655517578'
     longitude: -15.310139
-    longitude_dec: "-15.490884780883789"
     max_latitude: 13.825058
     max_longitude: -13.7913862
     min_latitude: 13.0098999

--- a/lib/countries/data/countries/GN.yaml
+++ b/lib/countries/data/countries/GN.yaml
@@ -34,9 +34,7 @@ GN:
   - ff
   geo:
     latitude: 9.945587
-    latitude_dec: '10.429302215576172'
     longitude: -9.696645
-    longitude_dec: "-10.98954963684082"
     max_latitude: 12.6748616
     max_longitude: -7.637853
     min_latitude: 7.190909099999999

--- a/lib/countries/data/countries/GP.yaml
+++ b/lib/countries/data/countries/GP.yaml
@@ -5,7 +5,7 @@ GP:
   alpha3: GLP
   country_code: '590'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: GP
   name: Guadeloupe
   national_destination_code_lengths:
@@ -31,9 +31,7 @@ GP:
   - fr
   geo:
     latitude: 16.265
-    latitude_dec: '16.256731033325195'
     longitude: -61.55099999999999
-    longitude_dec: "-61.56741714477539"
     max_latitude: 16.5572273
     max_longitude: -60.9473
     min_latitude: 15.742032

--- a/lib/countries/data/countries/GQ.yaml
+++ b/lib/countries/data/countries/GQ.yaml
@@ -35,9 +35,7 @@ GQ:
   - fr
   geo:
     latitude: 1.650801
-    latitude_dec: '1.5331259965896606'
     longitude: 10.267895
-    longitude_dec: '10.372581481933594'
     max_latitude: 3.8355
     max_longitude: 11.3333
     min_latitude: -1.5475

--- a/lib/countries/data/countries/GR.yaml
+++ b/lib/countries/data/countries/GR.yaml
@@ -48,9 +48,7 @@ GR:
   - el
   geo:
     latitude: 39.074208
-    latitude_dec: '39.68437194824219'
     longitude: 21.824312
-    longitude_dec: '21.897409439086914'
     max_latitude: 41.7488784
     max_longitude: 29.6527999
     min_latitude: 34.5428

--- a/lib/countries/data/countries/GS.yaml
+++ b/lib/countries/data/countries/GS.yaml
@@ -5,7 +5,7 @@ GS:
   alpha3: SGS
   country_code: '500'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: SX
   name: South Georgia and the South Sandwich Islands
   national_destination_code_lengths: []
@@ -31,9 +31,7 @@ GS:
   - en
   geo:
     latitude: -54.429579
-    latitude_dec: "-54.459922790527344"
     longitude: -36.587909
-    longitude_dec: "-36.354618072509766"
     max_latitude: -53.8525267
     max_longitude: -25.4663085
     min_latitude: -59.91097600000001

--- a/lib/countries/data/countries/GT.yaml
+++ b/lib/countries/data/countries/GT.yaml
@@ -30,9 +30,7 @@ GT:
   - es
   geo:
     latitude: 15.783471
-    latitude_dec: '15.670565605163574'
     longitude: -90.23075899999999
-    longitude_dec: "-90.3486557006836"
     max_latitude: 17.815697
     max_longitude: -88.1982001
     min_latitude: 13.63

--- a/lib/countries/data/countries/GU.yaml
+++ b/lib/countries/data/countries/GU.yaml
@@ -35,9 +35,7 @@ GU:
   - es
   geo:
     latitude: 13.444304
-    latitude_dec: '13.42112922668457'
     longitude: 144.793731
-    longitude_dec: '144.73971557617188'
     max_latitude: 13.7994072
     max_longitude: 145.112915
     min_latitude: 13.1022175

--- a/lib/countries/data/countries/GW.yaml
+++ b/lib/countries/data/countries/GW.yaml
@@ -33,9 +33,7 @@ GW:
   - pt
   geo:
     latitude: 11.803749
-    latitude_dec: '12.115862846374512'
     longitude: -15.180413
-    longitude_dec: "-14.748136520385742"
     max_latitude: 12.6869468
     max_longitude: -13.6265235
     min_latitude: 10.7146

--- a/lib/countries/data/countries/GY.yaml
+++ b/lib/countries/data/countries/GY.yaml
@@ -30,9 +30,7 @@ GY:
   - en
   geo:
     latitude: 4.860416
-    latitude_dec: '4.917311191558838'
     longitude: -58.93018
-    longitude_dec: "-58.94346237182617"
     max_latitude: 8.722199999999999
     max_longitude: -56.49112
     min_latitude: 1.164724

--- a/lib/countries/data/countries/HK.yaml
+++ b/lib/countries/data/countries/HK.yaml
@@ -37,9 +37,7 @@ HK:
   - zh
   geo:
     latitude: 22.3193039
-    latitude_dec: '22.336156845092773'
     longitude: 114.1693611
-    longitude_dec: '114.18696594238281'
     max_latitude: 22.5619469
     max_longitude: 114.4294999
     min_latitude: 22.1435

--- a/lib/countries/data/countries/HM.yaml
+++ b/lib/countries/data/countries/HM.yaml
@@ -5,7 +5,7 @@ HM:
   alpha3: HMD
   country_code: '672'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: HM
   name: Heard Island and McDonald Islands
   national_destination_code_lengths: []
@@ -31,9 +31,7 @@ HM:
   - en
   geo:
     latitude: -53.08181
-    latitude_dec: "-53.080108642578125"
     longitude: 73.50415799999999
-    longitude_dec: '73.56218719482422'
     max_latitude: -52.9609444
     max_longitude: 73.7792016
     min_latitude: -53.19168759999999

--- a/lib/countries/data/countries/HN.yaml
+++ b/lib/countries/data/countries/HN.yaml
@@ -31,9 +31,7 @@ HN:
   - es
   geo:
     latitude: 15.199999
-    latitude_dec: '14.975032806396484'
     longitude: -86.241905
-    longitude_dec: "-86.2647705078125"
     max_latitude: 17.4677999
     max_longitude: -83.0621001
     min_latitude: 12.9808201

--- a/lib/countries/data/countries/HR.yaml
+++ b/lib/countries/data/countries/HR.yaml
@@ -49,9 +49,7 @@ HR:
   - hr
   geo:
     latitude: 45.1
-    latitude_dec: '45.444305419921875'
     longitude: 15.2000001
-    longitude_dec: '15.734503746032715'
     max_latitude: 46.5549857
     max_longitude: 19.4480523
     min_latitude: 42.3385087

--- a/lib/countries/data/countries/HT.yaml
+++ b/lib/countries/data/countries/HT.yaml
@@ -33,9 +33,7 @@ HT:
   - ht
   geo:
     latitude: 18.971187
-    latitude_dec: '19.0732421875'
     longitude: -72.285215
-    longitude_dec: "-72.24127960205078"
     max_latitude: 20.1282
     max_longitude: -71.621754
     min_latitude: 17.9422

--- a/lib/countries/data/countries/HU.yaml
+++ b/lib/countries/data/countries/HU.yaml
@@ -50,9 +50,7 @@ HU:
   - hu
   geo:
     latitude: 47.162494
-    latitude_dec: '47.165733337402344'
     longitude: 19.5033041
-    longitude_dec: '19.416574478149414'
     max_latitude: 48.585234
     max_longitude: 22.8965438
     min_latitude: 45.7370889

--- a/lib/countries/data/countries/ID.yaml
+++ b/lib/countries/data/countries/ID.yaml
@@ -42,9 +42,7 @@ ID:
   - id
   geo:
     latitude: -0.789275
-    latitude_dec: "-1.248089075088501"
     longitude: 113.921327
-    longitude_dec: '115.41899871826172'
     max_latitude: 6.216999899999999
     max_longitude: 141.0425
     min_latitude: -11.1082999

--- a/lib/countries/data/countries/IE.yaml
+++ b/lib/countries/data/countries/IE.yaml
@@ -50,9 +50,7 @@ IE:
   - ga
   geo:
     latitude: 53.1423672
-    latitude_dec: '53.1827278137207'
     longitude: -7.692053599999999
-    longitude_dec: "-8.196102142333984"
     max_latitude: 55.38294149999999
     max_longitude: -5.431909999999999
     min_latitude: 51.4475448

--- a/lib/countries/data/countries/IL.yaml
+++ b/lib/countries/data/countries/IL.yaml
@@ -40,9 +40,7 @@ IL:
   - ar
   geo:
     latitude: 31.046051
-    latitude_dec: '31.814193725585938'
     longitude: 34.851612
-    longitude_dec: '34.75337219238281'
     max_latitude: 33.33280500000001
     max_longitude: 35.896244
     min_latitude: 29.47969999999999

--- a/lib/countries/data/countries/IM.yaml
+++ b/lib/countries/data/countries/IM.yaml
@@ -5,7 +5,7 @@ IM:
   alpha3: IMN
   country_code: '44'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: IM
   name: Isle of Man
   national_destination_code_lengths: []
@@ -33,9 +33,7 @@ IM:
   - gv
   geo:
     latitude: 54.236107
-    latitude_dec: '54.22451400756836'
     longitude: -4.548056
-    longitude_dec: "-4.562133312225342"
     max_latitude: 54.4369363
     max_longitude: -4.270618199999999
     min_latitude: 54.0186764

--- a/lib/countries/data/countries/IN.yaml
+++ b/lib/countries/data/countries/IN.yaml
@@ -40,9 +40,7 @@ IN:
   - en
   geo:
     latitude: 20.593684
-    latitude_dec: '23.4060115814209'
     longitude: 78.96288
-    longitude_dec: '79.45809173583984'
     max_latitude: 35.513327
     max_longitude: 97.39535869999999
     min_latitude: 6.4626999

--- a/lib/countries/data/countries/IO.yaml
+++ b/lib/countries/data/countries/IO.yaml
@@ -5,7 +5,7 @@ IO:
   alpha3: IOT
   country_code: '246'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: IO
   name: British Indian Ocean Territory
   national_destination_code_lengths: []
@@ -30,9 +30,7 @@ IO:
   - en
   geo:
     latitude: -6.343194
-    latitude_dec: "-6.196269989013672"
     longitude: 71.876519
-    longitude_dec: '71.34793090820312'
     max_latitude: -5.1401857
     max_longitude: 72.5880433
     min_latitude: -7.4891118

--- a/lib/countries/data/countries/IQ.yaml
+++ b/lib/countries/data/countries/IQ.yaml
@@ -34,9 +34,7 @@ IQ:
   - ar
   geo:
     latitude: 33.223191
-    latitude_dec: '33.044586181640625'
     longitude: 43.679291
-    longitude_dec: '43.77495574951172'
     max_latitude: 37.380645
     max_longitude: 48.6350999
     min_latitude: 29.0612079

--- a/lib/countries/data/countries/IR.yaml
+++ b/lib/countries/data/countries/IR.yaml
@@ -33,9 +33,7 @@ IR:
   - fa
   geo:
     latitude: 32.427908
-    latitude_dec: '32.50077819824219'
     longitude: 53.688046
-    longitude_dec: '54.2942008972168'
     max_latitude: 39.782056
     max_longitude: 63.3333366
     min_latitude: 24.8066999

--- a/lib/countries/data/countries/IS.yaml
+++ b/lib/countries/data/countries/IS.yaml
@@ -48,9 +48,7 @@ IS:
   - is
   geo:
     latitude: 64.963051
-    latitude_dec: '64.9285659790039'
     longitude: -19.020835
-    longitude_dec: "-18.961700439453125"
     max_latitude: 67.2466
     max_longitude: -12.2388001
     min_latitude: 62.4819

--- a/lib/countries/data/countries/IT.yaml
+++ b/lib/countries/data/countries/IT.yaml
@@ -48,9 +48,7 @@ IT:
   - it
   geo:
     latitude: 41.87194
-    latitude_dec: '42.7669792175293'
     longitude: 12.56738
-    longitude_dec: '12.493823051452637'
     max_latitude: 47.092
     max_longitude: 18.7975999
     min_latitude: 35.4897

--- a/lib/countries/data/countries/JE.yaml
+++ b/lib/countries/data/countries/JE.yaml
@@ -5,7 +5,7 @@ JE:
   alpha3: JEY
   country_code: '44'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: JE
   name: Jersey
   national_destination_code_lengths: []
@@ -30,9 +30,7 @@ JE:
   - fr
   geo:
     latitude: 49.214439
-    latitude_dec: '49.2285041809082'
     longitude: -2.13125
-    longitude_dec: "-2.1228928565979004"
     max_latitude: 49.26650009999999
     max_longitude: -2.0013001
     min_latitude: 49.1582

--- a/lib/countries/data/countries/JM.yaml
+++ b/lib/countries/data/countries/JM.yaml
@@ -32,9 +32,7 @@ JM:
   - en
   geo:
     latitude: 18.109581
-    latitude_dec: '18.143444061279297'
     longitude: -77.297508
-    longitude_dec: "-77.34654998779297"
     max_latitude: 18.5697821
     max_longitude: -76.1448669
     min_latitude: 17.6688854

--- a/lib/countries/data/countries/JO.yaml
+++ b/lib/countries/data/countries/JO.yaml
@@ -41,9 +41,7 @@ JO:
   - ar
   geo:
     latitude: 30.585164
-    latitude_dec: '31.2757625579834'
     longitude: 36.238414
-    longitude_dec: '36.82838821411133'
     max_latitude: 33.374735
     max_longitude: 39.301154
     min_latitude: 29.1850361

--- a/lib/countries/data/countries/JP.yaml
+++ b/lib/countries/data/countries/JP.yaml
@@ -38,9 +38,7 @@ JP:
   - ja
   geo:
     latitude: 36.204824
-    latitude_dec: '36.281646728515625'
     longitude: 138.252924
-    longitude_dec: '139.0772705078125'
     max_latitude: 45.6412626
     max_longitude: 154.0031455
     min_latitude: 20.3585295

--- a/lib/countries/data/countries/KE.yaml
+++ b/lib/countries/data/countries/KE.yaml
@@ -33,9 +33,7 @@ KE:
   - sw
   geo:
     latitude: -0.023559
-    latitude_dec: '0.5765031576156616'
     longitude: 37.906193
-    longitude_dec: '37.83988952636719'
     max_latitude: 5.033420899999999
     max_longitude: 41.9069449
     min_latitude: -4.724299999999999

--- a/lib/countries/data/countries/KG.yaml
+++ b/lib/countries/data/countries/KG.yaml
@@ -37,9 +37,7 @@ KG:
   - ru
   geo:
     latitude: 41.20438
-    latitude_dec: '41.46435546875'
     longitude: 74.766098
-    longitude_dec: '74.55522155761719'
     max_latitude: 43.2653569
     max_longitude: 80.2281514
     min_latitude: 39.180254

--- a/lib/countries/data/countries/KH.yaml
+++ b/lib/countries/data/countries/KH.yaml
@@ -34,9 +34,7 @@ KH:
   - km
   geo:
     latitude: 12.565679
-    latitude_dec: '12.570423126220703'
     longitude: 104.990963
-    longitude_dec: '104.81391143798828'
     max_latitude: 14.6901791
     max_longitude: 107.627687
     min_latitude: 9.6007

--- a/lib/countries/data/countries/KI.yaml
+++ b/lib/countries/data/countries/KI.yaml
@@ -29,9 +29,7 @@ KI:
   - en
   geo:
     latitude: -3.370417
-    latitude_dec: '1.842833161354065'
     longitude: -168.734039
-    longitude_dec: "-157.6758270263672"
     max_latitude: 5.4082108
     max_longitude: -145.1513674
     min_latitude: -13.0502263

--- a/lib/countries/data/countries/KM.yaml
+++ b/lib/countries/data/countries/KM.yaml
@@ -34,9 +34,7 @@ KM:
   - fr
   geo:
     latitude: -11.6455
-    latitude_dec: "-11.86610221862793"
     longitude: 43.3333
-    longitude_dec: '43.432640075683594'
     max_latitude: -11.3373321
     max_longitude: 44.5646666
     min_latitude: -12.4687602

--- a/lib/countries/data/countries/KN.yaml
+++ b/lib/countries/data/countries/KN.yaml
@@ -36,9 +36,7 @@ KN:
   - en
   geo:
     latitude: 17.357822
-    latitude_dec: '17.24447250366211'
     longitude: -62.782998
-    longitude_dec: "-62.643184661865234"
     max_latitude: 17.4205891
     max_longitude: -62.52369989999999
     min_latitude: 17.07861

--- a/lib/countries/data/countries/KP.yaml
+++ b/lib/countries/data/countries/KP.yaml
@@ -37,9 +37,7 @@ KP:
   - ko
   geo:
     latitude: 40.339852
-    latitude_dec: '40.077640533447266'
     longitude: 127.510093
-    longitude_dec: '127.13385009765625'
     max_latitude: 43.01159
     max_longitude: 130.6990167
     min_latitude: 37.5892001

--- a/lib/countries/data/countries/KR.yaml
+++ b/lib/countries/data/countries/KR.yaml
@@ -43,9 +43,7 @@ KR:
   - ko
   geo:
     latitude: 35.907757
-    latitude_dec: '40.077640533447266'
     longitude: 127.766922
-    longitude_dec: '127.13385009765625'
     max_latitude: 38.63400000000001
     max_longitude: 131.1603
     min_latitude: 33.0041

--- a/lib/countries/data/countries/KW.yaml
+++ b/lib/countries/data/countries/KW.yaml
@@ -39,9 +39,7 @@ KW:
   - ar
   geo:
     latitude: 29.31166
-    latitude_dec: '29.321941375732422'
     longitude: 47.481766
-    longitude_dec: '47.60246658325195'
     max_latitude: 30.1036993
     max_longitude: 48.5184
     min_latitude: 28.5244463

--- a/lib/countries/data/countries/KY.yaml
+++ b/lib/countries/data/countries/KY.yaml
@@ -35,9 +35,7 @@ KY:
   - en
   geo:
     latitude: 19.3133
-    latitude_dec: '19.308862686157227'
     longitude: -81.2546
-    longitude_dec: "-81.25680541992188"
     max_latitude: 19.7616
     max_longitude: -79.7191
     min_latitude: 19.2538999

--- a/lib/countries/data/countries/KZ.yaml
+++ b/lib/countries/data/countries/KZ.yaml
@@ -35,9 +35,7 @@ KZ:
   - ru
   geo:
     latitude: 48.019573
-    latitude_dec: '48.14600372314453'
     longitude: 66.923684
-    longitude_dec: '67.17916870117188'
     max_latitude: 55.4419839
     max_longitude: 87.315415
     min_latitude: 40.5685841

--- a/lib/countries/data/countries/LA.yaml
+++ b/lib/countries/data/countries/LA.yaml
@@ -31,9 +31,7 @@ LA:
   - lo
   geo:
     latitude: 19.85627
-    latitude_dec: '18.65074920654297'
     longitude: 102.495496
-    longitude_dec: '104.15293884277344'
     max_latitude: 22.5090449
     max_longitude: 107.635094
     min_latitude: 13.9097198

--- a/lib/countries/data/countries/LB.yaml
+++ b/lib/countries/data/countries/LB.yaml
@@ -41,9 +41,7 @@ LB:
   - fr
   geo:
     latitude: 33.854721
-    latitude_dec: '33.925411224365234'
     longitude: 35.862285
-    longitude_dec: '35.89972686767578'
     max_latitude: 34.69209
     max_longitude: 36.62372
     min_latitude: 33.0550256

--- a/lib/countries/data/countries/LC.yaml
+++ b/lib/countries/data/countries/LC.yaml
@@ -34,9 +34,7 @@ LC:
   - en
   geo:
     latitude: 13.909444
-    latitude_dec: '13.86330509185791'
     longitude: -60.978893
-    longitude_dec: "-60.9665641784668"
     max_latitude: 14.1209277
     max_longitude: -60.85979460000001
     min_latitude: 13.7047779

--- a/lib/countries/data/countries/LI.yaml
+++ b/lib/countries/data/countries/LI.yaml
@@ -31,9 +31,7 @@ LI:
   - de
   geo:
     latitude: 47.166
-    latitude_dec: '47.14126968383789'
     longitude: 9.555373
-    longitude_dec: '9.552783012390137'
     max_latitude: 47.2705467
     max_longitude: 9.6356501
     min_latitude: 47.04828999999999

--- a/lib/countries/data/countries/LK.yaml
+++ b/lib/countries/data/countries/LK.yaml
@@ -32,9 +32,7 @@ LK:
   - ta
   geo:
     latitude: 7.873053999999999
-    latitude_dec: '7.789133548736572'
     longitude: 80.77179699999999
-    longitude_dec: '80.68072509765625'
     max_latitude: 10.03377
     max_longitude: 82.14479999999999
     min_latitude: 5.6816

--- a/lib/countries/data/countries/LR.yaml
+++ b/lib/countries/data/countries/LR.yaml
@@ -32,9 +32,7 @@ LR:
   - en
   geo:
     latitude: 6.428055
-    latitude_dec: '6.411512851715088'
     longitude: -9.429499000000002
-    longitude_dec: "-9.323492050170898"
     max_latitude: 8.551986
     max_longitude: -7.3692549
     min_latitude: 4.269699999999999

--- a/lib/countries/data/countries/LS.yaml
+++ b/lib/countries/data/countries/LS.yaml
@@ -33,9 +33,7 @@ LS:
   - st
   geo:
     latitude: -29.609988
-    latitude_dec: "-29.58175277709961"
     longitude: 28.233608
-    longitude_dec: '28.246612548828125'
     max_latitude: -28.5708011
     max_longitude: 29.4557087
     min_latitude: -30.6755788

--- a/lib/countries/data/countries/LT.yaml
+++ b/lib/countries/data/countries/LT.yaml
@@ -45,9 +45,7 @@ LT:
   - lt
   geo:
     latitude: 55.169438
-    latitude_dec: '55.33871841430664'
     longitude: 23.881275
-    longitude_dec: '23.87092399597168'
     max_latitude: 56.45032089999999
     max_longitude: 26.835523
     min_latitude: 53.8967949

--- a/lib/countries/data/countries/LU.yaml
+++ b/lib/countries/data/countries/LU.yaml
@@ -50,9 +50,7 @@ LU:
   - lb
   geo:
     latitude: 49.815273
-    latitude_dec: '49.77788162231445'
     longitude: 6.129582999999999
-    longitude_dec: '6.094746112823486'
     max_latitude: 50.18282
     max_longitude: 6.530970099999999
     min_latitude: 49.447779

--- a/lib/countries/data/countries/LV.yaml
+++ b/lib/countries/data/countries/LV.yaml
@@ -48,9 +48,7 @@ LV:
   - lv
   geo:
     latitude: 56.879635
-    latitude_dec: '56.86873245239258'
     longitude: 24.603189
-    longitude_dec: '24.84024429321289'
     max_latitude: 58.0855688
     max_longitude: 28.2414029
     min_latitude: 55.6747769

--- a/lib/countries/data/countries/LY.yaml
+++ b/lib/countries/data/countries/LY.yaml
@@ -36,9 +36,7 @@ LY:
   - ar
   geo:
     latitude: 26.3351
-    latitude_dec: '27.23609733581543'
     longitude: 17.228331
-    longitude_dec: '18.043556213378906'
     max_latitude: 33.2203
     max_longitude: 25.2686
     min_latitude: 19.5

--- a/lib/countries/data/countries/MA.yaml
+++ b/lib/countries/data/countries/MA.yaml
@@ -34,9 +34,7 @@ MA:
   - ar
   geo:
     latitude: 31.791702
-    latitude_dec: '29.14059066772461'
     longitude: -7.092619999999999
-    longitude_dec: "-8.953388214111328"
     max_latitude: 35.9344
     max_longitude: -0.9969759
     min_latitude: 27.6672693

--- a/lib/countries/data/countries/MC.yaml
+++ b/lib/countries/data/countries/MC.yaml
@@ -32,9 +32,7 @@ MC:
   - fr
   geo:
     latitude: 43.73841760000001
-    latitude_dec: '43.738929748535156'
     longitude: 7.424615799999999
-    longitude_dec: '7.425483226776123'
     max_latitude: 43.7519029
     max_longitude: 7.4426
     min_latitude: 43.7237999

--- a/lib/countries/data/countries/MD.yaml
+++ b/lib/countries/data/countries/MD.yaml
@@ -35,9 +35,7 @@ MD:
   - ro
   geo:
     latitude: 47.411631
-    latitude_dec: '47.203704833984375'
     longitude: 28.369885
-    longitude_dec: '28.46834373474121'
     max_latitude: 48.492029
     max_longitude: 30.1635898
     min_latitude: 45.4674379

--- a/lib/countries/data/countries/ME.yaml
+++ b/lib/countries/data/countries/ME.yaml
@@ -37,9 +37,7 @@ ME:
   - hr
   geo:
     latitude: 42.708678
-    latitude_dec: '42.752803802490234'
     longitude: 19.37439
-    longitude_dec: '19.237918853759766'
     max_latitude: 43.558743
     max_longitude: 20.352926
     min_latitude: 41.8297

--- a/lib/countries/data/countries/MF.yaml
+++ b/lib/countries/data/countries/MF.yaml
@@ -5,7 +5,7 @@ MF:
   alpha3: MAF
   country_code: '590'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: RN
   name: Saint Martin (French part)
   national_destination_code_lengths: []
@@ -33,9 +33,7 @@ MF:
   - nl
   geo:
     latitude: 18.08255
-    latitude_dec: '18.042224884033203'
     longitude: -63.05225100000001
-    longitude_dec: "-63.06623458862305"
     max_latitude: 18.1356001
     max_longitude: -62.9613001
     min_latitude: 18.0462883

--- a/lib/countries/data/countries/MG.yaml
+++ b/lib/countries/data/countries/MG.yaml
@@ -34,9 +34,7 @@ MG:
   - mg
   geo:
     latitude: -18.766947
-    latitude_dec: "-19.27239418029785"
     longitude: 46.869107
-    longitude_dec: '46.69843292236328'
     max_latitude: -11.4369999
     max_longitude: 50.9985001
     min_latitude: -26.2146

--- a/lib/countries/data/countries/MH.yaml
+++ b/lib/countries/data/countries/MH.yaml
@@ -36,9 +36,7 @@ MH:
   - mh
   geo:
     latitude: 7.131474
-    latitude_dec: '7.286207675933838'
     longitude: 171.184478
-    longitude_dec: '168.75140380859375'
     max_latitude: 15.0190749
     max_longitude: 172.5732421
     min_latitude: 4.1601583

--- a/lib/countries/data/countries/MK.yaml
+++ b/lib/countries/data/countries/MK.yaml
@@ -42,9 +42,7 @@ MK:
   - mk
   geo:
     latitude: 41.608635
-    latitude_dec: '41.60045623779297'
     longitude: 21.745275
-    longitude_dec: '21.700895309448242'
     max_latitude: 42.373646
     max_longitude: 23.0340441
     min_latitude: 40.8537826

--- a/lib/countries/data/countries/ML.yaml
+++ b/lib/countries/data/countries/ML.yaml
@@ -29,9 +29,7 @@ ML:
   - fr
   geo:
     latitude: 17.570692
-    latitude_dec: '17.35776710510254'
     longitude: -3.996166
-    longitude_dec: "-3.5273818969726562"
     max_latitude: 25.001084
     max_longitude: 4.267382599999999
     min_latitude: 10.147811

--- a/lib/countries/data/countries/MM.yaml
+++ b/lib/countries/data/countries/MM.yaml
@@ -31,9 +31,7 @@ MM:
   - my
   geo:
     latitude: 21.916221
-    latitude_dec: '20.330142974853516'
     longitude: 95.955974
-    longitude_dec: '96.52182006835938'
     max_latitude: 28.5478351
     max_longitude: 101.1702717
     min_latitude: 9.4518

--- a/lib/countries/data/countries/MN.yaml
+++ b/lib/countries/data/countries/MN.yaml
@@ -36,9 +36,7 @@ MN:
   - mn
   geo:
     latitude: 46.862496
-    latitude_dec: '46.83647918701172'
     longitude: 103.846656
-    longitude_dec: '103.06689453125'
     max_latitude: 52.148355
     max_longitude: 119.9315098
     min_latitude: 41.581833

--- a/lib/countries/data/countries/MO.yaml
+++ b/lib/countries/data/countries/MO.yaml
@@ -5,7 +5,7 @@ MO:
   alpha3: MAC
   country_code: '853'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: MC
   name: Macao
   national_destination_code_lengths:
@@ -32,9 +32,7 @@ MO:
   - pt
   geo:
     latitude: 22.198745
-    latitude_dec: '22.140748977661133'
     longitude: 113.543873
-    longitude_dec: '113.56034088134766'
     max_latitude: 22.2170639
     max_longitude: 113.6127001
     min_latitude: 22.1066001

--- a/lib/countries/data/countries/MP.yaml
+++ b/lib/countries/data/countries/MP.yaml
@@ -5,7 +5,7 @@ MP:
   alpha3: MNP
   country_code: '1'
   international_prefix: '011'
-  ioc: 
+  ioc:
   gec: CQ
   name: Northern Mariana Islands
   national_destination_code_lengths:
@@ -36,9 +36,7 @@ MP:
   - ch
   geo:
     latitude: 15.0979
-    latitude_dec: '15.262779235839844'
     longitude: 145.6739
-    longitude_dec: '145.8045654296875'
     max_latitude: 20.6584862
     max_longitude: 146.2060546
     min_latitude: 13.9713848

--- a/lib/countries/data/countries/MQ.yaml
+++ b/lib/countries/data/countries/MQ.yaml
@@ -5,7 +5,7 @@ MQ:
   alpha3: MTQ
   country_code: '596'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: MB
   name: Martinique
   national_destination_code_lengths:
@@ -31,9 +31,7 @@ MQ:
   - fr
   geo:
     latitude: 14.641528
-    latitude_dec: '14.642807960510254'
     longitude: -61.024174
-    longitude_dec: "-60.97755432128906"
     max_latitude: 14.8973451
     max_longitude: -60.7856368
     min_latitude: 14.370834

--- a/lib/countries/data/countries/MR.yaml
+++ b/lib/countries/data/countries/MR.yaml
@@ -35,9 +35,7 @@ MR:
   - fr
   geo:
     latitude: 21.00789
-    latitude_dec: '20.258995056152344'
     longitude: -10.940835
-    longitude_dec: "-10.364437103271484"
     max_latitude: 27.3158916
     max_longitude: -4.833334799999999
     min_latitude: 14.721273

--- a/lib/countries/data/countries/MS.yaml
+++ b/lib/countries/data/countries/MS.yaml
@@ -6,7 +6,7 @@ MS:
   country_code: '1'
   nanp_prefix: '1664'
   international_prefix: '011'
-  ioc: 
+  ioc:
   gec: MH
   name: Montserrat
   national_destination_code_lengths:
@@ -30,9 +30,7 @@ MS:
   - en
   geo:
     latitude: 16.742498
-    latitude_dec: '16.735998153686523'
     longitude: -62.187366
-    longitude_dec: "-62.188819885253906"
     max_latitude: 16.8260672
     max_longitude: -62.14262009999999
     min_latitude: 16.671007

--- a/lib/countries/data/countries/MT.yaml
+++ b/lib/countries/data/countries/MT.yaml
@@ -42,9 +42,7 @@ MT:
   - en
   geo:
     latitude: 35.937496
-    latitude_dec: '35.93336486816406'
     longitude: 14.375416
-    longitude_dec: '14.381033897399902'
     max_latitude: 36.0853
     max_longitude: 14.5765999
     min_latitude: 35.79960000000001

--- a/lib/countries/data/countries/MU.yaml
+++ b/lib/countries/data/countries/MU.yaml
@@ -32,9 +32,7 @@ MU:
   - en
   geo:
     latitude: -20.348404
-    latitude_dec: "-20.220409393310547"
     longitude: 57.55215200000001
-    longitude_dec: '57.589378356933594'
     max_latitude: -10.0878538
     max_longitude: 63.80859390000001
     min_latitude: -20.7458403

--- a/lib/countries/data/countries/MV.yaml
+++ b/lib/countries/data/countries/MV.yaml
@@ -33,9 +33,7 @@ MV:
   - dv
   geo:
     latitude: 3.202778
-    latitude_dec: '4.185884952545166'
     longitude: 73.22068
-    longitude_dec: '73.53071594238281'
     max_latitude: 7.5149809
     max_longitude: 74.7290038
     min_latitude: -1.2907844

--- a/lib/countries/data/countries/MW.yaml
+++ b/lib/countries/data/countries/MW.yaml
@@ -31,9 +31,7 @@ MW:
   - ny
   geo:
     latitude: -13.254308
-    latitude_dec: "-13.523577690124512"
     longitude: 34.301525
-    longitude_dec: '33.83546447753906'
     max_latitude: -9.3672272
     max_longitude: 35.91857299999999
     min_latitude: -17.1295216

--- a/lib/countries/data/countries/MX.yaml
+++ b/lib/countries/data/countries/MX.yaml
@@ -29,8 +29,8 @@ MX:
   vat_rates:
     standard: 16
     reduced: []
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:
@@ -45,9 +45,7 @@ MX:
   - es
   geo:
     latitude: 23.634501
-    latitude_dec: '23.909093856811523'
     longitude: -102.552784
-    longitude_dec: "-102.6333999633789"
     max_latitude: 32.7186534
     max_longitude: -86.5887
     min_latitude: 14.3895

--- a/lib/countries/data/countries/MY.yaml
+++ b/lib/countries/data/countries/MY.yaml
@@ -36,9 +36,7 @@ MY:
   - en
   geo:
     latitude: 4.210484
-    latitude_dec: '2.5490005016326904'
     longitude: 101.975766
-    longitude_dec: '102.96261596679688'
     max_latitude: 7.5191
     max_longitude: 119.4000001
     min_latitude: 0.8539281000000001

--- a/lib/countries/data/countries/MZ.yaml
+++ b/lib/countries/data/countries/MZ.yaml
@@ -32,9 +32,7 @@ MZ:
   - pt
   geo:
     latitude: -18.665695
-    latitude_dec: "-17.555864334106445"
     longitude: 35.529562
-    longitude_dec: '35.955692291259766'
     max_latitude: -10.3128929
     max_longitude: 41.3965
     min_latitude: -26.9612

--- a/lib/countries/data/countries/NA.yaml
+++ b/lib/countries/data/countries/NA.yaml
@@ -36,9 +36,7 @@ NA:
   - af
   geo:
     latitude: -22.95764
-    latitude_dec: "-22.150699615478516"
     longitude: 18.49041
-    longitude_dec: '17.177526473999023'
     max_latitude: -16.9634849
     max_longitude: 25.261752
     min_latitude: -28.97063889999999

--- a/lib/countries/data/countries/NC.yaml
+++ b/lib/countries/data/countries/NC.yaml
@@ -5,7 +5,7 @@ NC:
   alpha3: NCL
   country_code: '687'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: NC
   name: New Caledonia
   national_destination_code_lengths:
@@ -34,9 +34,7 @@ NC:
   - fr
   geo:
     latitude: -20.904305
-    latitude_dec: "-21.31782341003418"
     longitude: 165.618042
-    longitude_dec: '165.298583984375'
     max_latitude: -19.1607355
     max_longitude: 168.3325194
     min_latitude: -23.2514406

--- a/lib/countries/data/countries/NE.yaml
+++ b/lib/countries/data/countries/NE.yaml
@@ -31,9 +31,7 @@ NE:
   - fr
   geo:
     latitude: 17.607789
-    latitude_dec: '17.424074172973633'
     longitude: 8.081666
-    longitude_dec: '9.400633811950684'
     max_latitude: 23.4999997
     max_longitude: 15.9990339
     min_latitude: 11.693756

--- a/lib/countries/data/countries/NF.yaml
+++ b/lib/countries/data/countries/NF.yaml
@@ -5,7 +5,7 @@ NF:
   alpha3: NFK
   country_code: '672'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: NF
   name: Norfolk Island
   national_destination_code_lengths:
@@ -34,9 +34,7 @@ NF:
   - en
   geo:
     latitude: -29.040835
-    latitude_dec: "-29.036962509155273"
     longitude: 167.954712
-    longitude_dec: '167.95523071289062'
     max_latitude: -28.9929014
     max_longitude: 167.9985523
     min_latitude: -29.137506

--- a/lib/countries/data/countries/NG.yaml
+++ b/lib/countries/data/countries/NG.yaml
@@ -23,8 +23,8 @@ NG:
   vat_rates:
     standard: 5
     reduced: []
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{6}"
   unofficial_names:
@@ -38,9 +38,7 @@ NG:
   - en
   geo:
     latitude: 9.081999
-    latitude_dec: '9.559505462646484'
     longitude: 8.675277
-    longitude_dec: '8.077880859375'
     max_latitude: 13.8856449
     max_longitude: 14.677982
     min_latitude: 4.1821001

--- a/lib/countries/data/countries/NI.yaml
+++ b/lib/countries/data/countries/NI.yaml
@@ -30,9 +30,7 @@ NI:
   - es
   geo:
     latitude: 12.865416
-    latitude_dec: '12.903773307800293'
     longitude: -85.207229
-    longitude_dec: "-84.92182159423828"
     max_latitude: 15.0297369
     max_longitude: -82.2766
     min_latitude: 10.7080549

--- a/lib/countries/data/countries/NL.yaml
+++ b/lib/countries/data/countries/NL.yaml
@@ -48,9 +48,7 @@ NL:
   - nl
   geo:
     latitude: 52.132633
-    latitude_dec: '52.34225845336914'
     longitude: 5.291265999999999
-    longitude_dec: '5.5281572341918945'
     max_latitude: 53.6316
     max_longitude: 7.227510199999999
     min_latitude: 50.75038379999999

--- a/lib/countries/data/countries/NO.yaml
+++ b/lib/countries/data/countries/NO.yaml
@@ -47,9 +47,7 @@
   - nn
   geo:
     latitude: 60.47202399999999
-    latitude_dec: '66.76667022705078'
     longitude: 8.468945999999999
-    longitude_dec: '14.899925231933594'
     max_latitude: 71.30780000000001
     max_longitude: 31.3549999
     min_latitude: 57.8097

--- a/lib/countries/data/countries/NP.yaml
+++ b/lib/countries/data/countries/NP.yaml
@@ -43,9 +43,7 @@ NP:
   - urd
   geo:
     latitude: 28.394857
-    latitude_dec: '28.259138107299805'
     longitude: 84.12400799999999
-    longitude_dec: '83.94416046142578'
     max_latitude: 30.4473898
     max_longitude: 88.20182969999999
     min_latitude: 26.3473741

--- a/lib/countries/data/countries/NR.yaml
+++ b/lib/countries/data/countries/NR.yaml
@@ -31,9 +31,7 @@ NR:
   - na
   geo:
     latitude: -0.522778
-    latitude_dec: "-0.5316064953804016"
     longitude: 166.931503
-    longitude_dec: '166.9364013671875'
     max_latitude: -0.4978976000000001
     max_longitude: 166.9631767
     min_latitude: -0.5580623

--- a/lib/countries/data/countries/NU.yaml
+++ b/lib/countries/data/countries/NU.yaml
@@ -5,7 +5,7 @@ NU:
   alpha3: NIU
   country_code: '683'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: NE
   name: Niue
   national_destination_code_lengths:
@@ -29,9 +29,7 @@ NU:
   - en
   geo:
     latitude: -19.054445
-    latitude_dec: "-19.03806495666504"
     longitude: -169.867233
-    longitude_dec: "-169.8302459716797"
     max_latitude: -18.952625
     max_longitude: -169.7743248
     min_latitude: -19.1555668

--- a/lib/countries/data/countries/NZ.yaml
+++ b/lib/countries/data/countries/NZ.yaml
@@ -30,8 +30,8 @@ NZ:
     standard: 15
     reduced:
     - 9
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:
@@ -47,9 +47,7 @@ NZ:
   - en
   geo:
     latitude: -40.900557
-    latitude_dec: "-44.05629348754883"
     longitude: 174.885971
-    longitude_dec: '170.35415649414062'
     max_latitude: -28.8773225
     max_longitude: -175.1235077
     min_latitude: -52.7224663

--- a/lib/countries/data/countries/OM.yaml
+++ b/lib/countries/data/countries/OM.yaml
@@ -38,9 +38,7 @@ OM:
   - ar
   geo:
     latitude: 21.4735329
-    latitude_dec: '20.566621780395508'
     longitude: 55.975413
-    longitude_dec: '56.157962799072266'
     max_latitude: 26.4361001
     max_longitude: 60.30399999999999
     min_latitude: 16.4571999

--- a/lib/countries/data/countries/PA.yaml
+++ b/lib/countries/data/countries/PA.yaml
@@ -31,9 +31,7 @@ PA:
   - es
   geo:
     latitude: 8.537981
-    latitude_dec: '8.646247863769531'
     longitude: -80.782127
-    longitude_dec: "-80.50607299804688"
     max_latitude: 9.7145001
     max_longitude: -77.1584879
     min_latitude: 7.0409

--- a/lib/countries/data/countries/PE.yaml
+++ b/lib/countries/data/countries/PE.yaml
@@ -33,9 +33,7 @@ PE:
   - es
   geo:
     latitude: -9.189967
-    latitude_dec: "-9.212532997131348"
     longitude: -75.015152
-    longitude_dec: "-74.422119140625"
     max_latitude: -0.0387769
     max_longitude: -68.65232879999999
     min_latitude: -18.4483

--- a/lib/countries/data/countries/PF.yaml
+++ b/lib/countries/data/countries/PF.yaml
@@ -5,7 +5,7 @@ PF:
   alpha3: PYF
   country_code: '689'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: FP
   name: French Polynesia
   national_destination_code_lengths:
@@ -34,9 +34,7 @@ PF:
   - fr
   geo:
     latitude: -17.679742
-    latitude_dec: "-17.648122787475586"
     longitude: -149.406843
-    longitude_dec: "-149.4647216796875"
     max_latitude: -6.4682
     max_longitude: -134.0551932
     min_latitude: -28.61346

--- a/lib/countries/data/countries/PG.yaml
+++ b/lib/countries/data/countries/PG.yaml
@@ -34,9 +34,7 @@ PG:
   - en
   geo:
     latitude: -6.314992999999999
-    latitude_dec: "-6.889159679412842"
     longitude: 143.95555
-    longitude_dec: '146.21444702148438'
     max_latitude: -0.6702
     max_longitude: 159.9609001
     min_latitude: -12.0823

--- a/lib/countries/data/countries/PH.yaml
+++ b/lib/countries/data/countries/PH.yaml
@@ -29,8 +29,8 @@ PH:
   vat_rates:
     standard: 12
     reduced: []
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{4}"
   unofficial_names:
@@ -47,9 +47,7 @@ PH:
   - en
   geo:
     latitude: 12.879721
-    latitude_dec: '11.112666130065918'
     longitude: 121.774017
-    longitude_dec: '122.50947570800781'
     max_latitude: 21.2412572
     max_longitude: 127.6444784
     min_latitude: 4.2259

--- a/lib/countries/data/countries/PK.yaml
+++ b/lib/countries/data/countries/PK.yaml
@@ -34,9 +34,7 @@ PK:
   - ur
   geo:
     latitude: 30.375321
-    latitude_dec: '29.923219680786133'
     longitude: 69.34511599999999
-    longitude_dec: '69.35774230957031'
     max_latitude: 37.0841069
     max_longitude: 77.8231711
     min_latitude: 23.6344999

--- a/lib/countries/data/countries/PL.yaml
+++ b/lib/countries/data/countries/PL.yaml
@@ -48,9 +48,7 @@ PL:
   - pl
   geo:
     latitude: 51.919438
-    latitude_dec: '52.147850036621094'
     longitude: 19.145136
-    longitude_dec: '19.37775993347168'
     max_latitude: 54.9054761
     max_longitude: 24.1458931
     min_latitude: 49.002025

--- a/lib/countries/data/countries/PM.yaml
+++ b/lib/countries/data/countries/PM.yaml
@@ -5,7 +5,7 @@ PM:
   alpha3: SPM
   country_code: '508'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: SB
   name: Saint Pierre and Miquelon
   national_destination_code_lengths:
@@ -34,9 +34,7 @@ PM:
   - fr
   geo:
     latitude: 46.8852
-    latitude_dec: '46.90594482421875'
     longitude: -56.3159
-    longitude_dec: "-56.336585998535156"
     max_latitude: 47.21579999999999
     max_longitude: -55.98249999999999
     min_latitude: 46.7003

--- a/lib/countries/data/countries/PN.yaml
+++ b/lib/countries/data/countries/PN.yaml
@@ -5,7 +5,7 @@ PN:
   alpha3: PCN
   country_code: '64'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: PC
   name: Pitcairn
   national_destination_code_lengths: []
@@ -31,9 +31,7 @@ PN:
   - en
   geo:
     latitude: -24.3767537
-    latitude_dec: "-24.372114181518555"
     longitude: -128.3242376
-    longitude_dec: "-128.31124877929688"
     max_latitude: -23.7928845
     max_longitude: -124.5410156
     min_latitude: -25.1776023

--- a/lib/countries/data/countries/PR.yaml
+++ b/lib/countries/data/countries/PR.yaml
@@ -32,9 +32,7 @@ PR:
   - en
   geo:
     latitude: 18.220833
-    latitude_dec: '18.2491397857666'
     longitude: -66.590149
-    longitude_dec: "-66.62803649902344"
     max_latitude: 18.5720479
     max_longitude: -65.2105715
     min_latitude: 17.8449191

--- a/lib/countries/data/countries/PS.yaml
+++ b/lib/countries/data/countries/PS.yaml
@@ -41,9 +41,7 @@ PS:
   - en
   geo:
     latitude: 31.952162
-    latitude_dec: '31.946392059326172'
     longitude: 35.233154
-    longitude_dec: '35.259735107421875'
     max_latitude: 32.5520999
     max_longitude: 35.5740521
     min_latitude: 31.219691

--- a/lib/countries/data/countries/PT.yaml
+++ b/lib/countries/data/countries/PT.yaml
@@ -44,9 +44,7 @@ PT:
   - pt
   geo:
     latitude: 39.39987199999999
-    latitude_dec: '39.64200973510742'
     longitude: -8.224454
-    longitude_dec: "-8.009422302246094"
     max_latitude: 42.1543111
     max_longitude: -6.189159200000001
     min_latitude: 32.2895

--- a/lib/countries/data/countries/PW.yaml
+++ b/lib/countries/data/countries/PW.yaml
@@ -30,9 +30,7 @@ PW:
   - en
   geo:
     latitude: 7.514979999999999
-    latitude_dec: '7.441900730133057'
     longitude: 134.58252
-    longitude_dec: '134.54205322265625'
     max_latitude: 8.238674
     max_longitude: 135.0769
     min_latitude: 2.6394

--- a/lib/countries/data/countries/PY.yaml
+++ b/lib/countries/data/countries/PY.yaml
@@ -32,9 +32,7 @@ PY:
   - gn
   geo:
     latitude: -23.442503
-    latitude_dec: "-23.24028968811035"
     longitude: -58.443832
-    longitude_dec: "-58.395172119140625"
     max_latitude: -19.2876589
     max_longitude: -54.258562
     min_latitude: -27.5817594

--- a/lib/countries/data/countries/QA.yaml
+++ b/lib/countries/data/countries/QA.yaml
@@ -36,9 +36,7 @@ QA:
   - ar
   geo:
     latitude: 25.354826
-    latitude_dec: '25.413625717163086'
     longitude: 51.183884
-    longitude_dec: '51.2602653503418'
     max_latitude: 26.2171
     max_longitude: 51.7144001
     min_latitude: 24.471118

--- a/lib/countries/data/countries/RE.yaml
+++ b/lib/countries/data/countries/RE.yaml
@@ -5,7 +5,7 @@ RE:
   alpha3: REU
   country_code: '262'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: RE
   name: Réunion
   national_destination_code_lengths:
@@ -32,9 +32,7 @@ RE:
   - fr
   geo:
     latitude: -21.115141
-    latitude_dec: "-21.146299362182617"
     longitude: 55.536384
-    longitude_dec: '55.631248474121094'
     max_latitude: -20.8671529
     max_longitude: 55.84487919999999
     min_latitude: -21.4035321

--- a/lib/countries/data/countries/RO.yaml
+++ b/lib/countries/data/countries/RO.yaml
@@ -48,9 +48,7 @@ RO:
   - ro
   geo:
     latitude: 45.943161
-    latitude_dec: '45.83774185180664'
     longitude: 24.96676
-    longitude_dec: '25.005935668945312'
     max_latitude: 48.26518
     max_longitude: 29.77839999999999
     min_latitude: 43.6186193

--- a/lib/countries/data/countries/RS.yaml
+++ b/lib/countries/data/countries/RS.yaml
@@ -33,9 +33,7 @@ RS:
   - sr
   geo:
     latitude: 44.016521
-    latitude_dec: '44.23297119140625'
     longitude: 21.005859
-    longitude_dec: '20.797958374023438'
     max_latitude: 46.190032
     max_longitude: 23.0063095
     min_latitude: 42.2315029

--- a/lib/countries/data/countries/RU.yaml
+++ b/lib/countries/data/countries/RU.yaml
@@ -41,9 +41,7 @@ RU:
   - ru
   geo:
     latitude: 61.52401
-    latitude_dec: '63.125186920166016'
     longitude: 105.318756
-    longitude_dec: '103.75398254394531'
     max_latitude: 82.1673907
     max_longitude: -168.97788
     min_latitude: 41.185353

--- a/lib/countries/data/countries/RW.yaml
+++ b/lib/countries/data/countries/RW.yaml
@@ -35,9 +35,7 @@ RW:
   - fr
   geo:
     latitude: -1.940278
-    latitude_dec: "-1.9999498128890991"
     longitude: 29.873888
-    longitude_dec: '29.926057815551758'
     max_latitude: -1.0473752
     max_longitude: 30.8991179
     min_latitude: -2.8399383

--- a/lib/countries/data/countries/SA.yaml
+++ b/lib/countries/data/countries/SA.yaml
@@ -42,9 +42,7 @@ SA:
   - ar
   geo:
     latitude: 23.885942
-    latitude_dec: '23.994726181030273'
     longitude: 45.079162
-    longitude_dec: '44.4013557434082'
     max_latitude: 32.154284
     max_longitude: 55.6666999
     min_latitude: 16.0036

--- a/lib/countries/data/countries/SB.yaml
+++ b/lib/countries/data/countries/SB.yaml
@@ -33,9 +33,7 @@ SB:
   - en
   geo:
     latitude: -9.64571
-    latitude_dec: "-9.548112869262695"
     longitude: 160.156194
-    longitude_dec: '160.01930236816406'
     max_latitude: -6.075011
     max_longitude: 168.0249023
     min_latitude: -12.6832149

--- a/lib/countries/data/countries/SC.yaml
+++ b/lib/countries/data/countries/SC.yaml
@@ -32,9 +32,7 @@ SC:
   - en
   geo:
     latitude: -4.679574
-    latitude_dec: "-4.669795036315918"
     longitude: 55.491977
-    longitude_dec: '55.47166061401367'
     max_latitude: -3.7091721
     max_longitude: 56.3928224
     min_latitude: -10.4716073

--- a/lib/countries/data/countries/SD.yaml
+++ b/lib/countries/data/countries/SD.yaml
@@ -36,9 +36,7 @@ SD:
   - en
   geo:
     latitude: 12.862807
-    latitude_dec: '16.085784912109375'
     longitude: 30.217636
-    longitude_dec: '30.087390899658203'
     max_latitude: 22.224918
     max_longitude: 38.69379989999999
     min_latitude: 9.3472209

--- a/lib/countries/data/countries/SE.yaml
+++ b/lib/countries/data/countries/SE.yaml
@@ -48,9 +48,7 @@ SE:
   - sv
   geo:
     latitude: 60.12816100000001
-    latitude_dec: '62.67497253417969'
     longitude: 18.643501
-    longitude_dec: '16.798059463500977'
     max_latitude: 69.0599709
     max_longitude: 24.1773101
     min_latitude: 55.0059799

--- a/lib/countries/data/countries/SG.yaml
+++ b/lib/countries/data/countries/SG.yaml
@@ -42,9 +42,7 @@ SG:
   - ta
   geo:
     latitude: 1.352083
-    latitude_dec: '1.3219958543777466'
     longitude: 103.819836
-    longitude_dec: '103.8205337524414'
     max_latitude: 1.4784001
     max_longitude: 104.0945001
     min_latitude: 1.1496

--- a/lib/countries/data/countries/SH.yaml
+++ b/lib/countries/data/countries/SH.yaml
@@ -5,7 +5,7 @@ SH:
   alpha3: SHN
   country_code: '290'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: SH
   name: Saint Helena, Ascension and Tristan da Cunha
   national_destination_code_lengths:
@@ -35,9 +35,7 @@ SH:
   - en
   geo:
     latitude: -24.1434812
-    latitude_dec: "-15.957334518432617"
     longitude: -10.0306945
-    longitude_dec: "-5.716914176940918"
     max_latitude: -7.1008926
     max_longitude: -5.0976561
     min_latitude: -41.0371886

--- a/lib/countries/data/countries/SI.yaml
+++ b/lib/countries/data/countries/SI.yaml
@@ -47,9 +47,7 @@ SI:
   - sl
   geo:
     latitude: 46.151241
-    latitude_dec: '46.1202392578125'
     longitude: 14.995463
-    longitude_dec: '14.820664405822754'
     max_latitude: 46.876659
     max_longitude: 16.6107038
     min_latitude: 45.4218356

--- a/lib/countries/data/countries/SJ.yaml
+++ b/lib/countries/data/countries/SJ.yaml
@@ -5,7 +5,7 @@ SJ:
   alpha3: SJM
   country_code: '47'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: SV
   name: Svalbard and Jan Mayen
   national_destination_code_lengths:
@@ -34,9 +34,7 @@ SJ:
   - 'no'
   geo:
     latitude: 77.55360399999999
-    latitude_dec: '71.04893493652344'
     longitude: 23.6702719
-    longitude_dec: "-8.195747375488281"
     max_latitude: 80.92842569999999
     max_longitude: 34.8046879
     min_latitude: 70.4662074

--- a/lib/countries/data/countries/SK.yaml
+++ b/lib/countries/data/countries/SK.yaml
@@ -47,9 +47,7 @@ SK:
   - sk
   geo:
     latitude: 48.669026
-    latitude_dec: '48.70748519897461'
     longitude: 19.699024
-    longitude_dec: '19.48488998413086'
     max_latitude: 49.613805
     max_longitude: 22.5658602
     min_latitude: 47.731159

--- a/lib/countries/data/countries/SL.yaml
+++ b/lib/countries/data/countries/SL.yaml
@@ -29,9 +29,7 @@ SL:
   - en
   geo:
     latitude: 8.460555
-    latitude_dec: '8.521441459655762'
     longitude: -11.779889
-    longitude_dec: "-11.843890190124512"
     max_latitude: 9.9999737
     max_longitude: -10.2716829
     min_latitude: 6.8446

--- a/lib/countries/data/countries/SM.yaml
+++ b/lib/countries/data/countries/SM.yaml
@@ -34,9 +34,7 @@ SM:
   - it
   geo:
     latitude: 43.94236
-    latitude_dec: '43.938133239746094'
     longitude: 12.457777
-    longitude_dec: '12.463393211364746'
     max_latitude: 43.992075
     max_longitude: 12.5167041
     min_latitude: 43.8936809

--- a/lib/countries/data/countries/SN.yaml
+++ b/lib/countries/data/countries/SN.yaml
@@ -31,9 +31,7 @@ SN:
   - fr
   geo:
     latitude: 14.497401
-    latitude_dec: '14.36251163482666'
     longitude: -14.452362
-    longitude_dec: "-14.531643867492676"
     max_latitude: 16.6929572
     max_longitude: -11.3457683
     min_latitude: 12.2649001

--- a/lib/countries/data/countries/SO.yaml
+++ b/lib/countries/data/countries/SO.yaml
@@ -35,9 +35,7 @@ SO:
   - ar
   geo:
     latitude: 5.152149
-    latitude_dec: '5.948267459869385'
     longitude: 46.199616
-    longitude_dec: '47.47360610961914'
     max_latitude: 12.3615
     max_longitude: 51.6138
     min_latitude: -1.8673

--- a/lib/countries/data/countries/SR.yaml
+++ b/lib/countries/data/countries/SR.yaml
@@ -30,9 +30,7 @@ SR:
   - nl
   geo:
     latitude: 3.919305
-    latitude_dec: '4.216928958892822'
     longitude: -56.027783
-    longitude_dec: "-55.889217376708984"
     max_latitude: 6.1295999
     max_longitude: -53.94289999999999
     min_latitude: 1.837306

--- a/lib/countries/data/countries/SS.yaml
+++ b/lib/countries/data/countries/SS.yaml
@@ -5,7 +5,7 @@ SS:
   alpha3: SSD
   country_code: '211'
   international_prefix: '0'
-  ioc: 
+  ioc:
   gec: OD
   name: South Sudan
   national_destination_code_lengths:
@@ -33,9 +33,7 @@ SS:
   - en
   geo:
     latitude: 6.876991899999999
-    latitude_dec: '7.303858280181885'
     longitude: 31.3069788
-    longitude_dec: '30.280752182006836'
     max_latitude: 12.236389
     max_longitude: 35.9489971
     min_latitude: 3.48898

--- a/lib/countries/data/countries/ST.yaml
+++ b/lib/countries/data/countries/ST.yaml
@@ -34,9 +34,7 @@ ST:
   - pt
   geo:
     latitude: 0.18636
-    latitude_dec: '0.275555282831192'
     longitude: 6.613080999999999
-    longitude_dec: '6.631628036499023'
     max_latitude: 1.8961687
     max_longitude: 7.658843900000001
     min_latitude: -0.09887689999999999

--- a/lib/countries/data/countries/SV.yaml
+++ b/lib/countries/data/countries/SV.yaml
@@ -31,9 +31,7 @@ SV:
   - es
   geo:
     latitude: 13.794185
-    latitude_dec: '13.671636581420898'
     longitude: -88.89653
-    longitude_dec: "-88.86363220214844"
     max_latitude: 14.4505567
     max_longitude: -87.6682
     min_latitude: 13.0473999

--- a/lib/countries/data/countries/SX.yaml
+++ b/lib/countries/data/countries/SX.yaml
@@ -6,7 +6,7 @@ SX:
   country_code: '1'
   nanp_prefix: '1721'
   international_prefix: '011'
-  ioc: 
+  ioc:
   gec: NN
   name: Sint Maarten (Dutch part)
   national_destination_code_lengths:
@@ -32,9 +32,7 @@ SX:
   - en
   geo:
     latitude: 18.04248
-    latitude_dec: '18.042224884033203'
     longitude: -63.05483
-    longitude_dec: "-63.06623458862305"
     max_latitude: 18.0641707
     max_longitude: -62.9784
     min_latitude: 17.9941

--- a/lib/countries/data/countries/SY.yaml
+++ b/lib/countries/data/countries/SY.yaml
@@ -41,9 +41,7 @@ SY:
   - ar
   geo:
     latitude: 34.80207499999999
-    latitude_dec: '35.03312683105469'
     longitude: 38.996815
-    longitude_dec: '38.473472595214844'
     max_latitude: 37.318693
     max_longitude: 42.376309
     min_latitude: 32.311136

--- a/lib/countries/data/countries/SZ.yaml
+++ b/lib/countries/data/countries/SZ.yaml
@@ -34,9 +34,7 @@ SZ:
   - ss
   geo:
     latitude: -26.522503
-    latitude_dec: "-26.565134048461914"
     longitude: 31.465866
-    longitude_dec: '31.49811363220215'
     max_latitude: -25.71792
     max_longitude: 32.1349067
     min_latitude: -27.317402

--- a/lib/countries/data/countries/TC.yaml
+++ b/lib/countries/data/countries/TC.yaml
@@ -6,7 +6,7 @@ TC:
   country_code: '1'
   nanp_prefix: '1649'
   international_prefix: '011'
-  ioc: 
+  ioc:
   gec: TK
   name: Turks and Caicos Islands
   national_destination_code_lengths:
@@ -36,9 +36,7 @@ TC:
   - en
   geo:
     latitude: 21.694025
-    latitude_dec: '21.758726119995117'
     longitude: -71.797928
-    longitude_dec: "-71.71514892578125"
     max_latitude: 22.0016285
     max_longitude: -71.05949989999999
     min_latitude: 21.1459922

--- a/lib/countries/data/countries/TD.yaml
+++ b/lib/countries/data/countries/TD.yaml
@@ -35,9 +35,7 @@ TD:
   - fr
   geo:
     latitude: 15.454166
-    latitude_dec: '15.367652893066406'
     longitude: 18.732207
-    longitude_dec: '18.66758155822754'
     max_latitude: 23.449228
     max_longitude: 24.0000011
     min_latitude: 7.442975

--- a/lib/countries/data/countries/TF.yaml
+++ b/lib/countries/data/countries/TF.yaml
@@ -5,7 +5,7 @@ TF:
   alpha3: ATF
   country_code: '262'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: FS
   name: French Southern Territories
   national_destination_code_lengths: []
@@ -32,9 +32,7 @@ TF:
   - fr
   geo:
     latitude: -49.280366
-    latitude_dec: "-49.563865661621094"
     longitude: 69.3485571
-    longitude_dec: '69.54277801513672'
     max_latitude: -45.7567331
     max_longitude: 70.6558228
     min_latitude: -50.0641918

--- a/lib/countries/data/countries/TG.yaml
+++ b/lib/countries/data/countries/TG.yaml
@@ -29,9 +29,7 @@ TG:
   - fr
   geo:
     latitude: 8.619543
-    latitude_dec: '8.513226509094238'
     longitude: 0.824782
-    longitude_dec: '0.9800975322723389'
     max_latitude: 11.139617
     max_longitude: 1.8089071
     min_latitude: 6.0812

--- a/lib/countries/data/countries/TH.yaml
+++ b/lib/countries/data/countries/TH.yaml
@@ -24,8 +24,8 @@ TH:
     standard: 7
     reduced:
     - 0
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:
@@ -39,9 +39,7 @@ TH:
   - th
   geo:
     latitude: 15.870032
-    latitude_dec: '14.48458194732666'
     longitude: 100.992541
-    longitude_dec: '100.85191345214844'
     max_latitude: 20.465143
     max_longitude: 105.636812
     min_latitude: 5.613038

--- a/lib/countries/data/countries/TJ.yaml
+++ b/lib/countries/data/countries/TJ.yaml
@@ -37,9 +37,7 @@ TJ:
   - ru
   geo:
     latitude: 38.861034
-    latitude_dec: '38.879764556884766'
     longitude: 71.276093
-    longitude_dec: '70.89906311035156'
     max_latitude: 41.044367
     max_longitude: 75.1539564
     min_latitude: 36.6719898

--- a/lib/countries/data/countries/TK.yaml
+++ b/lib/countries/data/countries/TK.yaml
@@ -5,7 +5,7 @@ TK:
   alpha3: TKL
   country_code: '690'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: TL
   name: Tokelau
   national_destination_code_lengths:
@@ -31,9 +31,7 @@ TK:
   - en
   geo:
     latitude: -9.200199999999999
-    latitude_dec: "-8.979207992553711"
     longitude: -171.8484
-    longitude_dec: "-172.2017059326172"
     max_latitude: -8.4221116
     max_longitude: -171.0928346
     min_latitude: -9.5059527

--- a/lib/countries/data/countries/TL.yaml
+++ b/lib/countries/data/countries/TL.yaml
@@ -33,9 +33,7 @@ TL:
   - pt
   geo:
     latitude: -8.874217
-    latitude_dec: "-8.804786682128906"
     longitude: 125.727539
-    longitude_dec: '126.07902526855469'
     max_latitude: -8.048399999999999
     max_longitude: 127.4249
     min_latitude: -9.5303001

--- a/lib/countries/data/countries/TM.yaml
+++ b/lib/countries/data/countries/TM.yaml
@@ -34,9 +34,7 @@ TM:
   - ru
   geo:
     latitude: 38.969719
-    latitude_dec: '39.2012825012207'
     longitude: 59.556278
-    longitude_dec: '59.082252502441406'
     max_latitude: 42.798844
     max_longitude: 66.70735309999999
     min_latitude: 35.12876

--- a/lib/countries/data/countries/TN.yaml
+++ b/lib/countries/data/countries/TN.yaml
@@ -37,9 +37,7 @@ TN:
   - fr
   geo:
     latitude: 33.886917
-    latitude_dec: '34.33528518676758'
     longitude: 9.537499
-    longitude_dec: '9.245259284973145'
     max_latitude: 37.5359
     max_longitude: 11.599217
     min_latitude: 30.2280339

--- a/lib/countries/data/countries/TO.yaml
+++ b/lib/countries/data/countries/TO.yaml
@@ -33,9 +33,7 @@ TO:
   - to
   geo:
     latitude: -21.178986
-    latitude_dec: "-21.147611618041992"
     longitude: -175.198242
-    longitude_dec: "-175.25067138671875"
     max_latitude: -15.4060236
     max_longitude: -173.2543946
     min_latitude: -21.8360059

--- a/lib/countries/data/countries/TR.yaml
+++ b/lib/countries/data/countries/TR.yaml
@@ -39,9 +39,7 @@ TR:
   - tr
   geo:
     latitude: 38.963745
-    latitude_dec: '39.05101013183594'
     longitude: 35.243322
-    longitude_dec: '34.93033981323242'
     max_latitude: 42.3666999
     max_longitude: 44.8178449
     min_latitude: 35.808592

--- a/lib/countries/data/countries/TT.yaml
+++ b/lib/countries/data/countries/TT.yaml
@@ -34,9 +34,7 @@ TT:
   - en
   geo:
     latitude: 10.691803
-    latitude_dec: '10.68574047088623'
     longitude: -61.222503
-    longitude_dec: "-61.1640625"
     max_latitude: 11.4004
     max_longitude: -60.45089989999999
     min_latitude: 9.9930001

--- a/lib/countries/data/countries/TV.yaml
+++ b/lib/countries/data/countries/TV.yaml
@@ -29,9 +29,7 @@ TV:
   - en
   geo:
     latitude: -7.109534999999999
-    latitude_dec: "-7.471305847167969"
     longitude: 177.64933
-    longitude_dec: '178.6740264892578'
     max_latitude: -5.4300853
     max_longitude: 179.9999999
     min_latitude: -11.1891797

--- a/lib/countries/data/countries/TW.yaml
+++ b/lib/countries/data/countries/TW.yaml
@@ -37,9 +37,7 @@ TW:
   - zh
   geo:
     latitude: 23.69781
-    latitude_dec: '23.685789108276367'
     longitude: 120.960515
-    longitude_dec: '120.89749145507812'
     max_latitude: 26.4545
     max_longitude: 123.5021012
     min_latitude: 20.5170001

--- a/lib/countries/data/countries/TZ.yaml
+++ b/lib/countries/data/countries/TZ.yaml
@@ -35,9 +35,7 @@ TZ:
   - en
   geo:
     latitude: -6.369028
-    latitude_dec: "-6.306897163391113"
     longitude: 34.888822
-    longitude_dec: '34.85392761230469'
     max_latitude: -0.9843968000000001
     max_longitude: 40.6398
     min_latitude: -11.7612539

--- a/lib/countries/data/countries/UA.yaml
+++ b/lib/countries/data/countries/UA.yaml
@@ -30,8 +30,8 @@ UA:
     standard: 20
     reduced:
     - 7
-    super_reduced: 
-    parking: 
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:
@@ -48,9 +48,7 @@ UA:
   - uk
   geo:
     latitude: 48.379433
-    latitude_dec: '48.92656326293945'
     longitude: 31.1655799
-    longitude_dec: '31.47578239440918'
     max_latitude: 52.3793713
     max_longitude: 40.2204802
     min_latitude: 44.2924

--- a/lib/countries/data/countries/UG.yaml
+++ b/lib/countries/data/countries/UG.yaml
@@ -32,9 +32,7 @@ UG:
   - sw
   geo:
     latitude: 1.373333
-    latitude_dec: '1.2773280143737793'
     longitude: 32.290275
-    longitude_dec: '32.389984130859375'
     max_latitude: 4.218628
     max_longitude: 35.0330489
     min_latitude: -1.4823178

--- a/lib/countries/data/countries/UM.yaml
+++ b/lib/countries/data/countries/UM.yaml
@@ -5,8 +5,8 @@ UM:
   alpha3: UMI
   country_code: '1'
   international_prefix: ''
-  ioc: 
-  gec: 
+  ioc:
+  gec:
   name: United States Minor Outlying Islands
   national_destination_code_lengths: []
   national_number_lengths: []
@@ -32,9 +32,7 @@ UM:
   - en
   geo:
     latitude: 19.2823192
-    latitude_dec: '19.282319'
     longitude: 166.647047
-    longitude_dec: '166.647047'
     max_latitude: 28.3977184
     max_longitude: -159.9849071
     min_latitude: -0.3824678

--- a/lib/countries/data/countries/US.yaml
+++ b/lib/countries/data/countries/US.yaml
@@ -41,16 +41,16 @@ US:
   geo:
     latitude: 37.09024
     longitude: -95.712891
-    max_latitude: 71.5388001
-    max_longitude: -66.885417
-    min_latitude: 18.7763
-    min_longitude: 170.5957
+    max_latitude: 71.3577635769
+    max_longitude: -66.96466
+    min_latitude: 18.91619
+    min_longitude: -171.791110603
     bounds:
       northeast:
-        lat: 71.5388001
-        lng: -66.885417
+        lat: 71.3577635769
+        lng: -66.96466
       southwest:
-        lat: 18.7763
-        lng: 170.5957
+        lat: 18.91619
+        lng: -171.791110603
   currency_code: USD
   start_of_week: sunday

--- a/lib/countries/data/countries/US.yaml
+++ b/lib/countries/data/countries/US.yaml
@@ -40,9 +40,7 @@ US:
   - en
   geo:
     latitude: 37.09024
-    latitude_dec: '39.44325637817383'
     longitude: -95.712891
-    longitude_dec: "-98.95733642578125"
     max_latitude: 71.5388001
     max_longitude: -66.885417
     min_latitude: 18.7763

--- a/lib/countries/data/countries/UY.yaml
+++ b/lib/countries/data/countries/UY.yaml
@@ -31,9 +31,7 @@ UY:
   - es
   geo:
     latitude: -32.522779
-    latitude_dec: "-32.96965408325195"
     longitude: -55.765835
-    longitude_dec: "-56.055908203125"
     max_latitude: -30.0852149
     max_longitude: -53.0779284
     min_latitude: -35.1558001

--- a/lib/countries/data/countries/UZ.yaml
+++ b/lib/countries/data/countries/UZ.yaml
@@ -36,9 +36,7 @@ UZ:
   - ru
   geo:
     latitude: 41.377491
-    latitude_dec: '41.77239227294922'
     longitude: 64.585262
-    longitude_dec: '63.14588928222656'
     max_latitude: 45.590075
     max_longitude: 73.148946
     min_latitude: 37.1722571

--- a/lib/countries/data/countries/VA.yaml
+++ b/lib/countries/data/countries/VA.yaml
@@ -5,7 +5,7 @@ VA:
   alpha3: VAT
   country_code: '39'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: VT
   name: Holy See
   national_destination_code_lengths:
@@ -37,9 +37,7 @@ VA:
   - la
   geo:
     latitude: 41.902916
-    latitude_dec: '41.90308380126953'
     longitude: 12.453389
-    longitude_dec: '12.452852249145508'
     max_latitude: 41.90744309999999
     max_longitude: 12.4583938
     min_latitude: 41.9001896

--- a/lib/countries/data/countries/VC.yaml
+++ b/lib/countries/data/countries/VC.yaml
@@ -37,9 +37,7 @@ VC:
   - en
   geo:
     latitude: 12.984305
-    latitude_dec: '13.217251777648926'
     longitude: -61.287228
-    longitude_dec: "-61.19344711303711"
     max_latitude: 13.4136657
     max_longitude: -61.0846
     min_latitude: 12.5294999

--- a/lib/countries/data/countries/VE.yaml
+++ b/lib/countries/data/countries/VE.yaml
@@ -30,9 +30,7 @@ VE:
   - es
   geo:
     latitude: 6.42375
-    latitude_dec: '7.665388584136963'
     longitude: -66.58973
-    longitude_dec: "-66.14541625976562"
     max_latitude: 12.6886
     max_longitude: -59.805666
     min_latitude: 0.6475291

--- a/lib/countries/data/countries/VG.yaml
+++ b/lib/countries/data/countries/VG.yaml
@@ -36,9 +36,7 @@ VG:
   - en
   geo:
     latitude: 18.420695
-    latitude_dec: '18.443071365356445'
     longitude: -64.639968
-    longitude_dec: "-64.57130432128906"
     max_latitude: 18.7539999
     max_longitude: -64.2651999
     min_latitude: 18.2899998

--- a/lib/countries/data/countries/VI.yaml
+++ b/lib/countries/data/countries/VI.yaml
@@ -36,9 +36,7 @@ VI:
   - en
   geo:
     latitude: 18.335765
-    latitude_dec: '17.75262451171875'
     longitude: -64.896335
-    longitude_dec: "-64.73542022705078"
     max_latitude: 18.4239
     max_longitude: -64.4391
     min_latitude: 17.5482999

--- a/lib/countries/data/countries/VN.yaml
+++ b/lib/countries/data/countries/VN.yaml
@@ -40,9 +40,7 @@ VN:
   - vi
   geo:
     latitude: 14.058324
-    latitude_dec: '16.9404296875'
     longitude: 108.277199
-    longitude_dec: '106.8164291381836'
     max_latitude: 23.3926504
     max_longitude: 109.6765
     min_latitude: 8.1952001

--- a/lib/countries/data/countries/VU.yaml
+++ b/lib/countries/data/countries/VU.yaml
@@ -35,9 +35,7 @@ VU:
   - fr
   geo:
     latitude: -15.376706
-    latitude_dec: "-16.376684188842773"
     longitude: 166.959158
-    longitude_dec: '167.5625'
     max_latitude: -12.8064449
     max_longitude: 170.5023193
     min_latitude: -20.5350773

--- a/lib/countries/data/countries/WF.yaml
+++ b/lib/countries/data/countries/WF.yaml
@@ -5,7 +5,7 @@ WF:
   alpha3: WLF
   country_code: '681'
   international_prefix: '19'
-  ioc: 
+  ioc:
   gec: WF
   name: Wallis and Futuna
   national_destination_code_lengths:
@@ -34,9 +34,7 @@ WF:
   - fr
   geo:
     latitude: -14.2938
-    latitude_dec: "-13.299612045288086"
     longitude: -178.1165
-    longitude_dec: "-176.1701202392578"
     max_latitude: -13.1303042
     max_longitude: -176.0971068
     min_latitude: -14.4187203

--- a/lib/countries/data/countries/WS.yaml
+++ b/lib/countries/data/countries/WS.yaml
@@ -32,9 +32,7 @@ WS:
   - en
   geo:
     latitude: -13.759029
-    latitude_dec: "-13.668972969055176"
     longitude: -172.104629
-    longitude_dec: "-172.322021484375"
     max_latitude: -13.4203449
     max_longitude: -171.3950515
     min_latitude: -14.0833012

--- a/lib/countries/data/countries/YE.yaml
+++ b/lib/countries/data/countries/YE.yaml
@@ -39,9 +39,7 @@ YE:
   - ar
   geo:
     latitude: 15.552727
-    latitude_dec: '15.888387680053711'
     longitude: 48.516388
-    longitude_dec: '47.48988723754883'
     max_latitude: 18.9996331
     max_longitude: 54.67899999999999
     min_latitude: 11.7975

--- a/lib/countries/data/countries/YT.yaml
+++ b/lib/countries/data/countries/YT.yaml
@@ -5,7 +5,7 @@ YT:
   alpha3: MYT
   country_code: '262'
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: MF
   name: Mayotte
   national_destination_code_lengths:
@@ -30,9 +30,7 @@ YT:
   - fr
   geo:
     latitude: -12.8275
-    latitude_dec: "-12.79636001586914"
     longitude: 45.166244
-    longitude_dec: '45.14227294921875'
     max_latitude: -12.5772665
     max_longitude: 45.32014849999999
     min_latitude: -13.0358332

--- a/lib/countries/data/countries/ZA.yaml
+++ b/lib/countries/data/countries/ZA.yaml
@@ -59,9 +59,7 @@ ZA:
   - zu
   geo:
     latitude: -30.559482
-    latitude_dec: "-29.046184539794922"
     longitude: 22.937506
-    longitude_dec: '25.06287956237793'
     max_latitude: -22.1254239
     max_longitude: 38.2216904
     min_latitude: -47.1313489

--- a/lib/countries/data/countries/ZM.yaml
+++ b/lib/countries/data/countries/ZM.yaml
@@ -32,9 +32,7 @@ ZM:
   - en
   geo:
     latitude: -13.133897
-    latitude_dec: "-13.458845138549805"
     longitude: 27.849332
-    longitude_dec: '27.788097381591797'
     max_latitude: -8.2032838
     max_longitude: 33.7090305
     min_latitude: -18.0774179

--- a/lib/countries/data/countries/ZW.yaml
+++ b/lib/countries/data/countries/ZW.yaml
@@ -38,9 +38,7 @@ ZW:
   - nd
   geo:
     latitude: -19.015438
-    latitude_dec: "-19.000280380249023"
     longitude: 29.154857
-    longitude_dec: '29.86876106262207'
     max_latitude: -15.6093188
     max_longitude: 33.068236
     min_latitude: -22.4219117

--- a/lib/countries/structure.rb
+++ b/lib/countries/structure.rb
@@ -11,9 +11,7 @@ module ISO3166
     'gec' => nil,
     'geo' => {
       'latitude' => nil,
-      'latitude_dec' => nil,
       'longitude' => nil,
-      'longitude_dec' => nil,
       'max_latitude' => nil,
       'max_longitude' => nil,
       'min_latitude' => nil,
@@ -63,9 +61,7 @@ module ISO3166
     'translations' => {},
     'geo' => {
       'latitude' => nil,
-      'latitude_dec' => nil,
       'longitude' => nil,
-      'longitude_dec' => nil,
       'max_latitude' => nil,
       'max_longitude' => nil,
       'min_latitude' => nil,

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -68,14 +68,6 @@ describe ISO3166::Country do
     expect(country.bounds['northeast']['lat']).to eq(71.5388001)
   end
 
-  it 'should return the decimal Latitude' do
-    expect(country.latitude_dec).to eq('39.44325637817383')
-  end
-
-  it 'should return the decimal Longitude' do
-    expect(country.longitude_dec).to eq('-98.95733642578125')
-  end
-
   it 'should return continent' do
     expect(country.continent).to eq('North America')
   end


### PR DESCRIPTION
Deprecate `latitude_dec` and `longitude_dec`, delegate to `latitude` and `longitude`.

`latitude` and `longitude` attributes have been using decimal values for years, and the `_dec` atrributes have not been updated with the rake task, so in several cases are outdated.

Deprecation will be release with 4.2, and subsequently these methods will be removed for 5.0

Also fixes #535 by setting UK's min/max coordinates to a more sane value. (From http//www.naturalearthdata.com)