### PR TITLE
Fix  French Southern Territories continent and region data

### DIFF
--- a/lib/countries/data/countries/TF.yaml
+++ b/lib/countries/data/countries/TF.yaml
@@ -1,23 +1,23 @@
 ---
 TF:
-  continent: Antarctica
+  continent: Africa
   alpha2: TF
   alpha3: ATF
   country_code: '262'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: FS
   name: French Southern Territories
   national_destination_code_lengths: []
   national_number_lengths: []
   national_prefix: ''
   number: '260'
-  region: ''
-  subregion: ''
+  region: Africa
+  subregion: Eastern Africa
   un_locode: TF
   nationality: French
   postal_code: false
-  world_region: APAC
+  world_region: EMEA
   unofficial_names:
   - French Southern Territories
   - Französische Süd- und Antarktisgebiete


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/List_of_countries_by_United_Nations_geoscheme,

French Southern Territories are in the EMEA world region, Africa region and Eastern Africa subregion. As such, the continent should also be Africa. Not ideal, because Adélie Land is in Antartica, but the remaining territories are islands. 