### PR TITLE
JE and IM currencies should be GBP

### DIFF
--- a/lib/countries/data/countries/IM.yaml
+++ b/lib/countries/data/countries/IM.yaml
@@ -5,7 +5,7 @@ IM:
   alpha3: IMN
   country_code: '44'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: IM
   name: Isle of Man
   national_destination_code_lengths: []
@@ -47,5 +47,5 @@ IM:
       southwest:
         lat: 54.0186764
         lng: -4.8736609
-  currency_code: IMP
+  currency_code: GBP
   start_of_week: monday

--- a/lib/countries/data/countries/JE.yaml
+++ b/lib/countries/data/countries/JE.yaml
@@ -5,7 +5,7 @@ JE:
   alpha3: JEY
   country_code: '44'
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: JE
   name: Jersey
   national_destination_code_lengths: []
@@ -44,5 +44,5 @@ JE:
       southwest:
         lat: 49.1582
         lng: -2.2602001
-  currency_code: JEP
+  currency_code: GBP
   start_of_week: monday


### PR DESCRIPTION
As per https://en.wikipedia.org/wiki/ISO_4217#Unofficial_currency_codes, IMP and JEP are not official ISO 4217 currencies.

Fixes #492