### PR TITLE
add VAT for Israel and Saudi Arabia

### DIFF
--- a/lib/countries/data/countries/IL.yaml
+++ b/lib/countries/data/countries/IL.yaml
@@ -26,6 +26,11 @@ IL:
   world_region: EMEA
   un_locode: IL
   nationality: Israeli
+  vat_rates:
+    standard: 17
+    reduced: []
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}(?:\\d{2})?"
   unofficial_names:

--- a/lib/countries/data/countries/SA.yaml
+++ b/lib/countries/data/countries/SA.yaml
@@ -25,6 +25,11 @@ SA:
   world_region: EMEA
   un_locode: SA
   nationality: Saudi Arabian
+  vat_rates:
+    standard: 15
+    reduced: []
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:


### PR DESCRIPTION
Adds 17 % VAT rate for Israel and 15 % for Saudi Arabia.

Sources:
- https://www.haaretz.com/israel-news/business/.premium-value-added-tax-is-down-as-of-today-but-its-not-out-1.5404351
- https://www.bbc.com/news/business-52612785