### PR TITLE
Update postal code regexes from rake task

### DIFF
--- a/lib/countries/data/countries/IL.yaml
+++ b/lib/countries/data/countries/IL.yaml
@@ -55,8 +55,6 @@ IL:
     reduced: []
     super_reduced:
     parking:
-  postal_code: true
-  postal_code_format: "\\d{5}(?:\\d{2})?"
   unofficial_names:
   - Israel
   - Israël

--- a/lib/countries/data/countries/KH.yaml
+++ b/lib/countries/data/countries/KH.yaml
@@ -36,7 +36,7 @@ KH:
   nationality: Cambodian
   number: '116'
   postal_code: true
-  postal_code_format: "\\d{5}"
+  postal_code_format: "\\d{5,6}"
   region: Asia
   start_of_week: monday
   subregion: South-Eastern Asia

--- a/lib/countries/data/countries/TW.yaml
+++ b/lib/countries/data/countries/TW.yaml
@@ -42,7 +42,7 @@ TW:
   nationality: Taiwanese
   number: '158'
   postal_code: true
-  postal_code_format: "\\d{3}(?:\\d{2})?"
+  postal_code_format: "\\d{3}(?:\\d{2,3})?"
   region: Asia
   start_of_week: monday
   subregion: Eastern Asia


### PR DESCRIPTION
A couple of postal code regexes got recently updated (fetched from `rake postal_codes:update`)

The diff for Israel shows that it's removed, but that's because it was duplicated (line 47-48 in the `IL.yaml` file)