### PR TITLE
Added subdivision_names_with_codes method in documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -153,6 +153,9 @@ c.nationality # => "American"
 ```ruby
 c.subdivisions # => {"CO" => {"name" => "Colorado", "names" => "Colorado"}, ... }
 c.states # => {"CO" => {"name" => "Colorado", "names" => "Colorado"}, ... }
+
+# Get specific translations for the country subdivisions
+c.subdivision_names_with_codes('es') #=> [ ..., ["Nuevo Hampshire", "NH"], ["Nueva Jersey", "NJ"], ... ]
 ```
 
 ### Location


### PR DESCRIPTION
I added the `subdivision_with_names_with_codes` method to the documentation with a small example of the output since I thought it might be useful to know it exists.