### PR TITLE
Corrected Portuguese subdivision names

### DIFF
--- a/lib/countries/data/subdivisions/PT.yaml
+++ b/lib/countries/data/subdivisions/PT.yaml
@@ -486,7 +486,7 @@
     nb: Guarda
     nl: Guarda
     pl: Dystrykt Guarda
-    pt: Distrito da Guarda
+    pt: Guarda
     ro: Districtul Guarda
     ru: Гуарда
     sr: Гварда

--- a/lib/countries/data/subdivisions/PT.yaml
+++ b/lib/countries/data/subdivisions/PT.yaml
@@ -86,7 +86,7 @@
     nb: Beja
     nl: Beja
     pl: Dystrykt Beja
-    pt: Distrito de Beja
+    pt: Beja
     ro: Districtul Beja
     ru: Бежа
     si: බෙජා දිස්ත්‍රික්කය
@@ -147,7 +147,7 @@
     nb: Braga
     nl: Braga
     pl: Dystrykt Braga
-    pt: Distrito de Braga
+    pt: Braga
     ro: Districtul Braga
     ru: Брага
     si: බ්‍රගා දිස්ත්‍රික්කය
@@ -252,7 +252,7 @@
     nb: Castelo Branco
     nl: Castelo Branco
     pl: Dystrykt Castelo Branco
-    pt: Distrito de Castelo Branco
+    pt: Castelo Branco
     ro: Districtul Castelo Branco
     ru: Каштелу-Бранку
     si: කැස්ටෙලෝ බ්‍රන්කෝ දිස්ත්‍රික්කය
@@ -313,7 +313,7 @@
     nb: Coimbra
     nl: Coimbra
     pl: Dystrykt Coimbra
-    pt: Distrito de Coimbra
+    pt: Coimbra
     ro: Districtul Coimbra
     ru: Коимбра
     si: කොයිම්බ්‍රා දිස්ත්‍රික්කය
@@ -372,7 +372,7 @@
     nb: Évora
     nl: Évora
     pl: Dystrykt Évora
-    pt: Distrito de Évora
+    pt: Évora
     ro: Districtul Évora
     ru: Эвора
     si: එවොරා දිස්ත්‍රික්කය
@@ -432,7 +432,7 @@
     nb: Faro
     nl: Faro
     pl: Dystrykt Faro
-    pt: Distrito de Faro
+    pt: Faro
     ro: Districtul Faro
     ru: Фару
     si: ෆාරො දිස්ත්‍රික්කය
@@ -539,7 +539,7 @@
     nb: Leiria
     nl: Leiria
     pl: Dystrykt Leiria
-    pt: Distrito de Leiria
+    pt: Leiria
     ro: Districtul Leiria
     ru: Лейрия
     si: ලේයිරියා දිස්ත්‍රික්කය
@@ -597,7 +597,7 @@
     nb: Lisboa
     nl: Lissabon
     pl: Dystrykt Lizbona
-    pt: Distrito de Lisboa
+    pt: Lisboa
     ro: Districtul Lisabona
     ru: Лиссабон
     sr: Лисабон
@@ -642,7 +642,7 @@
     nb: Portalegre
     nl: Portalegre
     pl: Dystrykt Portalegre
-    pt: Distrito de Portalegre
+    pt: Portalegre
     ro: Districtul Portalegre
     ru: Порталегри
     sr: Порталегре
@@ -741,7 +741,7 @@
     nb: Santarém
     nl: Santarém
     pl: Dystrykt Santarém
-    pt: Distrito de Santarém
+    pt: Santarém
     ro: Districtul Santarém
     ru: Сантарен
     si: සැන්ටරේම් දිස්ත්‍රික්කය
@@ -802,7 +802,7 @@
     nb: Setúbal
     nl: Setúbal
     pl: Dystrykt Setúbal
-    pt: Distrito de Setúbal
+    pt: Setúbal
     ro: Districtul Setúbal
     ru: Сетубал
     si: සෙටුබල් දිස්ත්‍රික්කය
@@ -862,7 +862,7 @@
     nb: Viana do Castelo
     nl: Viana do Castelo
     pl: Dystrykt Viana do Castelo
-    pt: Distrito de Viana do Castelo
+    pt: Viana do Castelo
     ro: Districtul Viana do Castelo
     ru: Виана-ду-Каштелу
     si: වියානා ඩො කැස්ටෙලෝ දිස්ත්‍රික්කය


### PR DESCRIPTION
Corrected the Portuguese translation of the Portuguese subdivisions.

The "Distrito de" before the district name was inconsistent (only appeared in some of the districts) and is unnecessary and redundant.