### PR TITLE
Refactor subdivision loading to respect the configured locales.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -256,6 +256,9 @@ ISO3166.configure do |config|
 end
 ```
 
+If you change the value of `ISO3166.configuration.locales` after initialization, you should call `ISO3166::Data.reset` to reset the data cache, or you may end up with inconsistently loaded locales.
+As of 5.1.1, subdivision translations also respect this and will only load the selected locales.
+
 ## Loading Custom Data
 
 As of 2.0 countries supports loading custom countries / overriding data in its data set, though if you choose to do this please contribute back to the upstream repo!

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -58,9 +58,9 @@ module ISO3166
     # @return [Array<ISO3166::Subdivision>] the list of subdivisions for this Country.
     def subdivisions
       @subdivisions ||= if data['subdivisions']
-                          self.class.create_subdivisions(data['subdivisions'])
+                          ISO3166::Data.create_subdivisions(data['subdivisions'])
                         else
-                          self.class.subdivisions(alpha2)
+                          ISO3166::Data.subdivisions(alpha2)
                         end
     end
 

--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -64,17 +64,6 @@ module ISO3166
       translations.merge(custom_countries)
     end
 
-    def subdivisions(alpha2)
-      @subdivisions ||= {}
-      @subdivisions[alpha2] ||= create_subdivisions(subdivision_data(alpha2))
-    end
-
-    def create_subdivisions(subdivision_data)
-      subdivision_data.each_with_object({}) do |(k, v), hash|
-        hash[k] = Subdivision.new(v)
-      end
-    end
-
     protected
 
     def strip_accents(string)
@@ -83,15 +72,6 @@ module ISO3166
       else
         string.to_s.unaccent.downcase
       end
-    end
-
-    def subdivision_data(alpha2)
-      file = subdivision_file_path(alpha2)
-      File.exist?(file) ? YAML.load_file(file) : {}
-    end
-
-    def subdivision_file_path(alpha2)
-      File.join(File.dirname(__FILE__), '..', 'data', 'subdivisions', "#{alpha2}.yaml")
     end
 
     # Some methods like parse_value are expensive in that they

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -26,6 +26,17 @@ describe ISO3166::Data do
     expect(data['translated_names'].size).to eq 1
   end
 
+  it 'only loads subdivision translations for the configured locales' do
+    ISO3166.configuration.locales = %i[en]
+    ISO3166::Data.reset
+    subdivisions = ISO3166::Data.subdivisions('US')
+    expect(subdivisions.values.first['translations'].keys).to eq(%w[en])
+    ISO3166.configuration.locales = %i[es de en]
+    ISO3166::Data.reset
+    subdivisions = ISO3166::Data.subdivisions('US')
+    expect(subdivisions.values.first['translations'].keys).to eq(%w[es de en])
+  end
+
   describe '#codes' do
     it 'returns an array' do
       data = ISO3166::Data.codes


### PR DESCRIPTION
- Move subdivision loading code to `Data` class
- During data load, keep only subdivision translations for the configured locales
- `Data.reset` also resets loaded subdivisions

Fixes #580