### PR TITLE
Add an alternative name for USVI lookup

### DIFF
--- a/lib/countries/data/countries/VI.yaml
+++ b/lib/countries/data/countries/VI.yaml
@@ -50,4 +50,5 @@ VI:
   - Amerikaanse Maagdeneilanden
   - Virgin Islands (U.S.)
   - United States Virgin Islands
+  - U.S. Virgin Islands
   world_region: AMER


### PR DESCRIPTION
Looking up for an address in Virgin Islands US using Google Maps API responds with U.S. Virgin Islands as the country name:
    
```json
{
  "long_name" : "U.S. Virgin Islands",
  "short_name" : "VI",
  "types" : [ "country", "political" ]
},
```

<img width="667" alt="CleanShot 2022-07-15 at 11 53 12@2x" src="https://user-images.githubusercontent.com/17839/179204558-9861514d-7d6f-4705-aa8d-a758fb4ee779.png">
 
This country name isn't specified as an unofficial name so lookup fails:
    
```ruby
[1] pry(main)> IS
O3166::Country.find_country_by_any_name("U.S. Virgin Islands")
=> nil
```
