### PR TITLE
Replace sixarm_ruby_unaccent with unaccent

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.7'
 
-  gem.add_dependency('sixarm_ruby_unaccent', '~> 1.1')
+  gem.add_dependency('unaccent', '~> 0.3')
   gem.add_development_dependency('activesupport', '>= 3')
   gem.add_development_dependency('nokogiri', '>= 1.8')
   gem.add_development_dependency('rspec', '>= 3')

--- a/lib/countries.rb
+++ b/lib/countries.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'sixarm_ruby_unaccent'
-
 require 'countries/version'
 
 require 'countries/iso3166'

--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'sixarm_ruby_unaccent'
+require 'unaccent'
 
 module ISO3166
   UNSEARCHABLE_METHODS = [:translations].freeze
@@ -68,9 +68,9 @@ module ISO3166
 
     def strip_accents(string)
       if string.is_a?(Regexp)
-        Regexp.new(string.source.unaccent, 'i')
+        Regexp.new(Unaccent.unaccent(string.source), 'i')
       else
-        string.to_s.unaccent.downcase
+        Unaccent.unaccent(string.to_s).downcase
       end
     end
 


### PR DESCRIPTION
This replaces [sixarm_ruby_unaccent](https://github.com/SixArm/sixarm_ruby_unaccent) with [unaccent](https://github.com/hardpixel/unaccent) (Disclaimer: I'm the author of unaccent). Unaccent uses the same accentmap as sixarm_ruby_unaccent so there will be not differences in the final output.

What it does differently is to auto-load the accentmap and use gsub to replace the accented characters. This results in faster conversions and less memory usage as you can see [here](https://github.com/hardpixel/unaccent#benchmark). Also the string extension is optional.

