### PR TITLE
german translations for CI and CV

### DIFF
--- a/lib/countries/data/translations/countries-de.yaml
+++ b/lib/countries/data/translations/countries-de.yaml
@@ -46,7 +46,7 @@ CD: Demokratische Republik Kongo
 CF: Zentralafrikanische Republik
 CG: Kongo
 CH: Schweiz
-CI: Côte d'Ivoire
+CI: Elfenbeinküste
 CK: Cookinseln
 CL: Chile
 CM: Kamerun
@@ -54,7 +54,7 @@ CN: China
 CO: Kolumbien
 CR: Costa Rica
 CU: Kuba
-CV: Cabo Verde
+CV: Kap Verde
 CW: Curaçao
 CX: Weihnachtsinseln
 CY: Zypern


### PR DESCRIPTION
These are the regular used names for Cabo Verde and Cote d'Ivoire in Germany.