### PR TITLE
Updated Taiwan unofficial names

### DIFF
--- a/lib/countries/data/countries/TW.yaml
+++ b/lib/countries/data/countries/TW.yaml
@@ -8,7 +8,7 @@ TW:
   alpha2: TW
   alpha3: TWN
   continent: Asia
-  country_code: '886'
+  country_code: "886"
   currency_code: TWD
   gec: TW
   geo:
@@ -25,22 +25,22 @@ TW:
       southwest:
         lat: 20.5170001
         lng: 116.6665
-  international_prefix: '002'
+  international_prefix: "002"
   ioc: TPE
   iso_long_name: The Republic of China
   iso_short_name: Taiwan, Province of China
   languages_official:
-  - zh
+    - zh
   languages_spoken:
-  - zh
+    - zh
   national_destination_code_lengths:
-  - 2
+    - 2
   national_number_lengths:
-  - 7
-  - 8
-  national_prefix: '0'
+    - 7
+    - 8
+  national_prefix: "0"
   nationality: Taiwanese
-  number: '158'
+  number: "158"
   postal_code: true
   postal_code_format: "\\d{3}(?:\\d{2,3})?"
   region: Asia
@@ -48,7 +48,9 @@ TW:
   subregion: Eastern Asia
   un_locode: TW
   unofficial_names:
-  - Taiwan
-  - Taiwán
-  - 台灣
+    - Taiwan
+    - Taiwán
+    - 台灣
+    - 臺灣
+    - 台湾
   world_region: APAC


### PR DESCRIPTION
Unofficial names of Taiwan updated with:
- Traditional Chinese name: '臺灣'
- Simplified Chinese name: '台湾'