### PR TITLE
Remove "Province of China" from Taiwan's short name

### DIFF
--- a/lib/countries/data/countries/TW.yaml
+++ b/lib/countries/data/countries/TW.yaml
@@ -28,7 +28,7 @@ TW:
   international_prefix: "002"
   ioc: TPE
   iso_long_name: The Republic of China
-  iso_short_name: Taiwan, Province of China
+  iso_short_name: Taiwan
   languages_official:
     - zh
   languages_spoken:


### PR DESCRIPTION
That's just not the fact at all : )