### PR TITLE
Document how to get country codes (alpha2) [ci skip]

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,6 +26,13 @@ Simply load a new country object using Country.new(*alpha2*) or the shortcut Cou
 c = ISO3166::Country.new('US')
 ```
 
+Get all country codes (*alpha2*).
+
+```ruby
+ISO3166::Country.codes
+#  ["TJ", "JM", "HT",...]
+```
+
 ## Configuration
 
 ### Country Helper


### PR DESCRIPTION
It took me some time to figure out how to get an array of country codes. 
So I'd rather make it visible. 
My use case: I want to validate a country code user input against `ISO3166::Country.codes`.

Country codes are also called alpha2 in the documentation. This made it harder to find that the `ISO3166::Country.codes` method actually returns alpha2.