### PR TITLE
Duplicate `I18n.available_locales` into `default_locales`

### DIFF
--- a/lib/countries/configuration.rb
+++ b/lib/countries/configuration.rb
@@ -48,7 +48,7 @@ module ISO3166
 
     def default_locales
       locales = if Object.const_defined?('I18n') && I18n.respond_to?(:available_locales)
-                  I18n.available_locales
+                  I18n.available_locales.dup
                 else
                   [:en]
                 end


### PR DESCRIPTION
Duplicate `I18n.available_locales` into `default_locales` to prevent accidental changes to the original array

Fixes #768