### PR TITLE
Added G20 and G7 member fields

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -111,6 +111,15 @@ module ISO3166
       data['eu_member'].nil? ? false : data['eu_member']
     end
 
+    
+    def in_g7?
+      data['g7_member'].nil? ? false : data['g7_member']
+    end
+
+    def in_g20?
+      data['g20_member'].nil? ? false : data['g20_member']
+    end
+
     # +true+ if this country is a member of the European Economic Area.
     def in_eea?
       data['eea_member'].nil? ? false : data['eea_member']

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -111,11 +111,12 @@ module ISO3166
       data['eu_member'].nil? ? false : data['eu_member']
     end
 
-    
+    # +true+ if this country is a member of the G7.
     def in_g7?
       data['g7_member'].nil? ? false : data['g7_member']
     end
 
+    # +true+ if this country is a member of the G20.
     def in_g20?
       data['g20_member'].nil? ? false : data['g20_member']
     end

--- a/lib/countries/data/countries/AR.yaml
+++ b/lib/countries/data/countries/AR.yaml
@@ -11,6 +11,7 @@ AR:
   continent: South America
   country_code: '54'
   currency_code: ARS
+  g20_member: true
   gec: AR
   geo:
     latitude: -38.416097

--- a/lib/countries/data/countries/AU.yaml
+++ b/lib/countries/data/countries/AU.yaml
@@ -10,6 +10,7 @@ AU:
   continent: Australia
   country_code: '61'
   currency_code: AUD
+  g20_member: true
   gec: AS
   geo:
     latitude: -25.274398

--- a/lib/countries/data/countries/BR.yaml
+++ b/lib/countries/data/countries/BR.yaml
@@ -10,6 +10,7 @@ BR:
   continent: South America
   country_code: '55'
   currency_code: BRL
+  g20_member: true
   gec: BR
   geo:
     latitude: -14.235004

--- a/lib/countries/data/countries/CA.yaml
+++ b/lib/countries/data/countries/CA.yaml
@@ -10,6 +10,8 @@ CA:
   continent: North America
   country_code: '1'
   currency_code: CAD
+  g7_member: true
+  g20_member: true
   gec: CA
   geo:
     latitude: 56.130366

--- a/lib/countries/data/countries/CN.yaml
+++ b/lib/countries/data/countries/CN.yaml
@@ -10,6 +10,7 @@ CN:
   continent: Asia
   country_code: '86'
   currency_code: CNY
+  g20_member: true
   gec: CH
   geo:
     latitude: 35.86166

--- a/lib/countries/data/countries/DE.yaml
+++ b/lib/countries/data/countries/DE.yaml
@@ -12,6 +12,8 @@ DE:
   currency_code: EUR
   eea_member: true
   eu_member: true
+  g7_member: true
+  g20_member: true
   gec: GM
   geo:
     latitude: 51.165691

--- a/lib/countries/data/countries/FR.yaml
+++ b/lib/countries/data/countries/FR.yaml
@@ -12,6 +12,8 @@ FR:
   currency_code: EUR
   eea_member: true
   eu_member: true
+  g7_member: true
+  g20_member: true
   gec: FR
   geo:
     latitude: 46.227638

--- a/lib/countries/data/countries/GB.yaml
+++ b/lib/countries/data/countries/GB.yaml
@@ -14,6 +14,8 @@ GB:
   currency_code: GBP
   eea_member: false
   eu_member: false
+  g7_member: true
+  g20_member: true
   gec: UK
   geo:
     latitude: 55.378051

--- a/lib/countries/data/countries/ID.yaml
+++ b/lib/countries/data/countries/ID.yaml
@@ -11,6 +11,7 @@ ID:
   continent: Asia
   country_code: '62'
   currency_code: IDR
+  g20_member: true
   gec: ID
   geo:
     latitude: -0.789275

--- a/lib/countries/data/countries/IN.yaml
+++ b/lib/countries/data/countries/IN.yaml
@@ -11,6 +11,7 @@ IN:
   continent: Asia
   country_code: '91'
   currency_code: INR
+  g20_member: true
   gec: IN
   geo:
     latitude: 20.593684

--- a/lib/countries/data/countries/IT.yaml
+++ b/lib/countries/data/countries/IT.yaml
@@ -12,6 +12,8 @@ IT:
   currency_code: EUR
   eea_member: true
   eu_member: true
+  g7_member: true
+  g20_member: true
   gec: IT
   geo:
     latitude: 41.87194

--- a/lib/countries/data/countries/JP.yaml
+++ b/lib/countries/data/countries/JP.yaml
@@ -10,6 +10,8 @@ JP:
   continent: Asia
   country_code: '81'
   currency_code: JPY
+  g7_member: true
+  g20_member: true
   gec: JA
   geo:
     latitude: 36.204824

--- a/lib/countries/data/countries/KR.yaml
+++ b/lib/countries/data/countries/KR.yaml
@@ -11,6 +11,7 @@ KR:
   continent: Asia
   country_code: '82'
   currency_code: KRW
+  g20_member: true
   gec: KS
   geo:
     latitude: 35.907757

--- a/lib/countries/data/countries/MX.yaml
+++ b/lib/countries/data/countries/MX.yaml
@@ -10,6 +10,7 @@ MX:
   continent: North America
   country_code: '52'
   currency_code: MXN
+  g20_member: true
   gec: MX
   geo:
     latitude: 23.634501

--- a/lib/countries/data/countries/RU.yaml
+++ b/lib/countries/data/countries/RU.yaml
@@ -10,6 +10,7 @@ RU:
   continent: Europe
   country_code: '7'
   currency_code: RUB
+  g20_member: true
   gec: RS
   geo:
     latitude: 61.52401

--- a/lib/countries/data/countries/SA.yaml
+++ b/lib/countries/data/countries/SA.yaml
@@ -10,6 +10,7 @@ SA:
   continent: Asia
   country_code: '966'
   currency_code: SAR
+  g20_member: true
   gec: SA
   geo:
     latitude: 23.885942

--- a/lib/countries/data/countries/TR.yaml
+++ b/lib/countries/data/countries/TR.yaml
@@ -10,6 +10,7 @@ TR:
   continent: Europe
   country_code: '90'
   currency_code: TRY
+  g20_member: true
   gec: TU
   geo:
     latitude: 38.963745

--- a/lib/countries/data/countries/US.yaml
+++ b/lib/countries/data/countries/US.yaml
@@ -10,6 +10,8 @@ US:
   continent: North America
   country_code: '1'
   currency_code: USD
+  g7_member: true
+  g20_member: true
   gec: US
   geo:
     latitude: 37.09024

--- a/lib/countries/data/countries/ZA.yaml
+++ b/lib/countries/data/countries/ZA.yaml
@@ -12,6 +12,7 @@ ZA:
   continent: Africa
   country_code: '27'
   currency_code: ZAR
+  g20_member: true
   gec: SF
   geo:
     latitude: -30.559482


### PR DESCRIPTION
Added G20 and G7 member fields.
- G7 members: Canada, France, Germany, Italy, Japan, the United Kingdom and the United States
- G20 members: Argentina, Australia, Brazil, Canada, China, France, Germany, India, Indonesia, Italy, Japan, Mexico, Russia, Saudi Arabia, South Africa, South Korea, Turkey, the U.K. and the U.S.

Two methods, in_g7? and in_g20?, were added to check if a country is a member.