### PR TITLE
Adding gdpr_compliant method to check if a country is regulated by GDPR

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ c.in_esm? # => false
 c.in_eu_vat? # => false
 ```
 
+### GDPR Compliant (European Economic Area Membership or UK)
+
+```ruby
+c.gdpr_compliant # => false
+```
+
 ### Country Code in Emoji
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ c.in_eu_vat? # => false
 ### GDPR Compliant (European Economic Area Membership or UK)
 
 ```ruby
-c.gdpr_compliant # => false
+c.gdpr_compliant? # => false
 ```
 
 ### Country Code in Emoji

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -66,6 +66,11 @@ module ISO3166
       data['g20_member'].nil? ? false : data['g20_member']
     end
 
+    # +true+ if this country is a member of the European Economic Area or it is UK
+    def gdpr_compliant
+      in_eea? || alpha2 == 'GB'
+    end
+
     # +true+ if this country is a member of the European Economic Area.
     def in_eea?
       data['eea_member'].nil? ? false : data['eea_member']

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -67,8 +67,8 @@ module ISO3166
     end
 
     # +true+ if this country is a member of the European Economic Area or it is UK
-    def gdpr_compliant
-      in_eea? || alpha2 == 'GB'
+    def gdpr_compliant?
+      data['eea_member'] || alpha2 == 'GB'
     end
 
     # +true+ if this country is a member of the European Economic Area.

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -1080,6 +1080,24 @@ describe ISO3166::Country do
     end
   end
 
+  describe 'gdpr_compliant' do
+    let(:united_kigndom) { ISO3166::Country.search('GB') }
+    let(:france) { ISO3166::Country.search('FR') }
+    let(:mexico) { ISO3166::Country.search('MX') }
+
+    it 'should return false for countries without eea_member flag' do
+      expect(mexico.gdpr_compliant).to be_falsey
+    end
+
+    it 'should return true for countries with eea_member flag set to true' do
+      expect(france.gdpr_compliant).to be_truthy
+    end
+
+    it 'should return true for UK' do
+      expect(united_kigndom.gdpr_compliant).to be_truthy
+    end
+  end
+
   describe 'in_esm?' do
     let(:netherlands) { ISO3166::Country.search('NL') }
     let(:switzerland) { ISO3166::Country.search('CH') }

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -1080,21 +1080,21 @@ describe ISO3166::Country do
     end
   end
 
-  describe 'gdpr_compliant' do
+  describe 'gdpr_compliant?' do
     let(:united_kigndom) { ISO3166::Country.search('GB') }
     let(:france) { ISO3166::Country.search('FR') }
     let(:mexico) { ISO3166::Country.search('MX') }
 
     it 'should return false for countries without eea_member flag' do
-      expect(mexico.gdpr_compliant).to be_falsey
+      expect(mexico.gdpr_compliant?).to be_falsey
     end
 
     it 'should return true for countries with eea_member flag set to true' do
-      expect(france.gdpr_compliant).to be_truthy
+      expect(france.gdpr_compliant?).to be_truthy
     end
 
     it 'should return true for UK' do
-      expect(united_kigndom.gdpr_compliant).to be_truthy
+      expect(united_kigndom.gdpr_compliant?).to be_truthy
     end
   end
 


### PR DESCRIPTION
### Overview
* If a country is part of the European Economic Area, they must adhere to the regulations set forth in the General Data Protection Regulation (GDPR). This decision was made through Decision No. 154/2018, which extended the reach of the EU's GDPR law to all EEA jurisdictions that weren't members of the EU.

* Even though the UK has left the EU as of January 2021, the GDPR was already in effect and remains a valid UK law.

* To ensure that the UK is included as a GDPR-compliant country, this Pull Request is necessary as the current `eea` flag does not provide this information.

