### PR TITLE
Fix Taiwan's iso_long_name not matching ISO data.

### DIFF
--- a/lib/countries/data/countries/TW.yaml
+++ b/lib/countries/data/countries/TW.yaml
@@ -27,7 +27,7 @@ TW:
         lng: 116.6665
   international_prefix: "002"
   ioc: TPE
-  iso_long_name: The Republic of China
+  iso_long_name: Taiwan, Province of China
   iso_short_name: Taiwan, Province of China
   languages_official:
     - zh


### PR DESCRIPTION
 Fixes #809