### PR TITLE
Remove duplicate key in subdivisions/US.yaml

### DIFF
--- a/lib/countries/data/subdivisions/US.yaml
+++ b/lib/countries/data/subdivisions/US.yaml
@@ -1087,7 +1087,6 @@ GA:
     uz: Jorjiya
     bs: Georgia
     mk: Џорџија
-    tk: Jorjiýa
     'no': Georgia
     ha: Georgia (Tarayyar Amurka)
     ha_NE: Georgia (Tarayyar Amurka)


### PR DESCRIPTION
In the file `lib/countries/data/subdivisions/US.yaml` under "GA/translations" the key "tk" is duplicated. This can cause problems with libraries that do strict checks like [`go-yaml.v3`](https://github.com/go-yaml/yaml).
This PR removes the duplicate key.