### PR TITLE
Only include /lib in package

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
                         'wiki_uri' => 'https://github.com/countries/countries/wiki',
                         'rubygems_mfa_required' => 'true' }
 
-  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  gem.files         = `git ls-files lib`.split($OUTPUT_RECORD_SEPARATOR)
   gem.require_paths = ['lib']
 
   gem.required_ruby_version = '>= 2.7'


### PR DESCRIPTION
The packaged gem currently includes `/.github`, `/bin`, and `/spec`.