### PR TITLE
Add national number length to Palestine (PS)

### DIFF
--- a/lib/countries/data/countries/PS.yaml
+++ b/lib/countries/data/countries/PS.yaml
@@ -38,6 +38,7 @@ PS:
   - 2
   national_number_lengths:
   - 8
+  - 9
   national_prefix: '0'
   nationality: Palestinian
   number: '275'


### PR DESCRIPTION
The mobile number length in Palestine is 9.