### PR TITLE
add more national length to PS

### DIFF
--- a/lib/countries/data/countries/PS.yaml
+++ b/lib/countries/data/countries/PS.yaml
@@ -37,7 +37,9 @@ PS:
   national_destination_code_lengths:
   - 2
   national_number_lengths:
+  - 7
   - 8
+  - 9
   national_prefix: '0'
   nationality: Palestinian
   number: '275'


### PR DESCRIPTION
The phone number used in Palestine is the same as in Israel, so when using validating mobile numbers, the national number length shall include 9