### PR TITLE
Freeze Strings

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -10,13 +10,13 @@ module ISO3166
 
     ISO3166::DEFAULT_COUNTRY_HASH.each do |method_name, _type|
       define_method method_name do
-        data[method_name.to_s]
+        data[method_name.to_s].freeze
       end
     end
 
     ISO3166::DEFAULT_COUNTRY_HASH['geo'].each do |method_name, _type|
       define_method method_name do
-        data['geo'][method_name.to_s]
+        data['geo'][method_name.to_s].freeze
       end
     end
 

--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -48,7 +48,7 @@ module ISO3166
     end
 
     def translations(locale = 'en')
-      locale = locale.downcase
+      locale = locale.downcase.freeze
       file_path = ISO3166::Data.datafile_path(%W[locales #{locale}.json])
       translations = JSON.parse(File.read(file_path))
 

--- a/lib/countries/country/country_subdivision_methods.rb
+++ b/lib/countries/country/country_subdivision_methods.rb
@@ -43,7 +43,7 @@ module ISO3166
     # @return [Array<String>] the list of humanized subdivision types for this country. Uses ActiveSupport's `#humanize` if available
     def humanized_subdivision_types
       if String.instance_methods.include?(:humanize)
-        subdivisions.map { |_k, v| v['type'].humanize }.uniq
+        subdivisions.map { |_k, v| v['type'].humanize.freeze }.uniq
       else
         subdivisions.map { |_k, v| humanize_string(v['type']) }.uniq
       end
@@ -76,7 +76,7 @@ module ISO3166
     private
 
     def humanize_string(str)
-      str[0].upcase + str.tr('_', ' ')[1..]
+      (str[0].upcase + str.tr('_', ' ')[1..]).freeze
     end
   end
 end

--- a/lib/countries/country/emoji.rb
+++ b/lib/countries/country/emoji.rb
@@ -35,7 +35,7 @@ module ISO3166
     #
     # The emoji flag for this country, using Unicode Regional Indicator characters. e.g: "U+1F1FA U+1F1F8" for 🇺🇸
     def emoji_flag
-      alpha2.downcase.chars.map { |c| CODE_POINTS[c] }.join
+      alpha2.downcase.chars.map { |c| CODE_POINTS[c] }.join.freeze
     end
   end
 end

--- a/lib/countries/country/finder_methods.rb
+++ b/lib/countries/country/finder_methods.rb
@@ -63,7 +63,7 @@ module ISO3166
     end
 
     def parse_value(value)
-      value = value.gsub(SEARCH_TERM_FILTER_REGEX, '') if value.respond_to?(:gsub)
+      value = value.gsub(SEARCH_TERM_FILTER_REGEX, '').freeze if value.respond_to?(:gsub)
       strip_accents(value)
     end
 


### PR DESCRIPTION
At work, we've been using this gem at scale (serving ~ 20-100M req/month), and detected this gem to pollute memory by allocating way too many strings.

We've been running this adjustment of freezing multiple strings for six months now without issues (and measurably lower memory footprint).

Sadly, I couldn't find our exact memory profiling results anymore (we did extensive before/after tests using the memory profiler gem and observing memory footprint on the servers).

I remember, that strings for country codes got allocated multiple times before, and only once after freeze strings.

Thank you for maintaining open source :-)