### PR TITLE
Updates for India subdivision codes

### DIFF
--- a/lib/countries/data/subdivisions/IN.yaml
+++ b/lib/countries/data/subdivisions/IN.yaml
@@ -559,9 +559,9 @@ CH:
     az: Çandiqarh
   comments:
   type: union_territory
-CT:
+CG:
   name: Chhattisgarh
-  code: CT
+  code: CG
   unofficial_names: Chhattisgarh
   geo:
     latitude: 21.2786567
@@ -2231,9 +2231,9 @@ NL:
     my: နာဂလန်ပြည်နယ်
   comments:
   type: state
-OR:
-  name: Orissa
-  code: OR
+OD:
+  name: Odisha
+  code: OD
   unofficial_names: Orissa
   geo:
     latitude: 20.9516658
@@ -2690,9 +2690,9 @@ SK:
     uz: Sekkim
   comments:
   type: state
-TG:
+TS:
   name: तेलंगाना
-  code: TG
+  code: TS
   unofficial_names:
   geo:
     latitude:
@@ -3057,9 +3057,9 @@ UP:
     sd: اتر پرديش
   comments:
   type: state
-UT:
+UK:
   name: उत्तराखण्ड
-  code: UT
+  code: UK
   unofficial_names:
   geo:
     latitude:


### PR DESCRIPTION
Changes of subdivision codes from India: 
1. CT => 'CG' 
2. OR => 'OD' 
3. TG => 'TS' 
4. UT => 'UK'

<img width="988" alt="image" src="https://github.com/countries/countries/assets/109097544/c3b581a8-8feb-41da-bcc1-6dded43b4d01">

#### reference: 
https://en.wikipedia.org/wiki/ISO_3166-2:IN
https://www.iso.org/obp/ui/#iso:code:3166:IN