### PR TITLE
Update language and reduced VAT rate for Czechia

### DIFF
--- a/lib/countries/data/countries/CZ.yaml
+++ b/lib/countries/data/countries/CZ.yaml
@@ -34,10 +34,8 @@ CZ:
   iso_short_name: Czechia
   languages_official:
   - cs
-  - sk
   languages_spoken:
   - cs
-  - sk
   national_destination_code_lengths:
   - 2
   national_number_lengths:

--- a/lib/countries/data/countries/CZ.yaml
+++ b/lib/countries/data/countries/CZ.yaml
@@ -61,7 +61,7 @@ CZ:
   vat_rates:
     standard: 21
     reduced:
-    - 15
+    - 12
     super_reduced:
     parking:
   world_region: EMEA


### PR DESCRIPTION
This PR contains updates to languages and VAT rates for Czechia.

The only official language in Czechia is Czech. Slovak is also no longer considered a spoken language as it's only spoken by the Slovak minority nowadays.

https://european-union.europa.eu/principles-countries-history/country-profiles/czechia_en

As of 1 January 2024, the reduced VAT rate was changed to 12%.

https://www.globalvatcompliance.com/vat-rates-in-czech-republic/