### PR TITLE
Update GT subdivisions

### DIFF
--- a/lib/countries/data/subdivisions/GT.yaml
+++ b/lib/countries/data/subdivisions/GT.yaml
@@ -1,7 +1,7 @@
 ---
-AV:
+'16':
   name: Alta Verapaz
-  code: AV
+  code: '16'
   unofficial_names: Alta Verapaz
   geo:
     latitude: 15.5942883
@@ -61,9 +61,9 @@ AV:
     'no': Alta Verapaz
   comments:
   type: department
-BV:
+'15':
   name: Baja Verapaz
-  code: BV
+  code: '15'
   unofficial_names: Baja Verapaz
   geo:
     latitude: 15.0787498
@@ -122,9 +122,9 @@ BV:
     'no': Baja Verapaz
   comments:
   type: department
-CM:
+'04':
   name: Chimaltenango
-  code: CM
+  code: '04'
   unofficial_names: Chimaltenango
   geo:
     latitude: 14.662222
@@ -183,9 +183,9 @@ CM:
     'no': Chimaltenango
   comments:
   type: department
-CQ:
+'20':
   name: Chiquimula
-  code: CQ
+  code: '20'
   unofficial_names: Chiquimula
   geo:
     latitude: 14.783333
@@ -242,9 +242,9 @@ CQ:
     'no': Chiquimula
   comments:
   type: department
-ES:
+'05':
   name: Escuintla
-  code: ES
+  code: '05'
   unofficial_names: Escuintla
   geo:
     latitude: 14.3009389
@@ -302,9 +302,9 @@ ES:
     'no': Escuintla
   comments:
   type: department
-GU:
+'01':
   name: Guatemala
-  code: GU
+  code: '01'
   unofficial_names: Guatemala
   geo:
     latitude: 14.613333
@@ -365,9 +365,9 @@ GU:
     'no': Guatemala
   comments:
   type: department
-HU:
+'13':
   name: Huehuetenango
-  code: HU
+  code: '13'
   unofficial_names: Huehuetenango
   geo:
     latitude: 15.314722
@@ -425,9 +425,9 @@ HU:
     'no': Huehuetenango
   comments:
   type: department
-IZ:
+'18':
   name: Izabal
-  code: IZ
+  code: '18'
   unofficial_names: Izabal
   geo:
     latitude: 15.4036847
@@ -485,9 +485,9 @@ IZ:
     'no': Izabal
   comments:
   type: department
-JA:
+'21':
   name: Jalapa
-  code: JA
+  code: '21'
   unofficial_names: Jalapa
   geo:
     latitude: 14.5655154
@@ -545,9 +545,9 @@ JA:
     'no': Jalapa
   comments:
   type: department
-JU:
+'22':
   name: Jutiapa
-  code: JU
+  code: '22'
   unofficial_names: Jutiapa
   geo:
     latitude: 14.282778
@@ -606,9 +606,9 @@ JU:
     'no': Jutiapa
   comments:
   type: department
-PE:
+'17':
   name: Petén
-  code: PE
+  code: '17'
   unofficial_names: Petén
   geo:
     latitude: 16.912033
@@ -668,9 +668,9 @@ PE:
     'no': Petén
   comments:
   type: department
-PR:
+'02':
   name: El Progreso
-  code: PR
+  code: '02'
   unofficial_names: El Progreso
   geo:
     latitude: 14.86527
@@ -728,9 +728,9 @@ PR:
     'no': El Progreso
   comments:
   type: department
-QC:
+'14':
   name: Quiché
-  code: QC
+  code: '14'
   unofficial_names: Quiché
   geo:
     latitude: 15.4983808
@@ -788,9 +788,9 @@ QC:
     'no': Quiché
   comments:
   type: department
-QZ:
+'09':
   name: Quetzaltenango
-  code: QZ
+  code: '09'
   unofficial_names:
   - Quetzaltenango
   geo:
@@ -851,9 +851,9 @@ QZ:
     'no': Quetzaltenango
   comments:
   type: department
-RE:
+'11':
   name: Retalhuleu
-  code: RE
+  code: '11'
   unofficial_names: Retalhuleu
   geo:
     latitude: 14.533333
@@ -912,9 +912,9 @@ RE:
     'no': Retalhuleu
   comments:
   type: department
-SA:
+'03':
   name: Sacatepéquez
-  code: SA
+  code: '03'
   unofficial_names: Sacatepéquez
   geo:
     latitude: 14.6110576
@@ -974,9 +974,9 @@ SA:
     'no': Sacatepéquez
   comments:
   type: department
-SM:
+'12':
   name: San Marcos
-  code: SM
+  code: '12'
   unofficial_names: San Marcos
   geo:
     latitude: 14.9309569
@@ -1034,9 +1034,9 @@ SM:
     'no': San Marcos (departement)
   comments:
   type: department
-SO:
+'07':
   name: Sololá
-  code: SO
+  code: '07'
   unofficial_names: Sololá
   geo:
     latitude: 14.773889
@@ -1094,9 +1094,9 @@ SO:
     'no': Sololá
   comments:
   type: department
-SR:
+'06':
   name: Santa Rosa
-  code: SR
+  code: '06'
   unofficial_names: Santa Rosa
   geo:
     latitude: 14.1928003
@@ -1156,9 +1156,9 @@ SR:
     'no': Santa Rosa (departement)
   comments:
   type: department
-SU:
+'10':
   name: Suchitepéquez
-  code: SU
+  code: '10'
   unofficial_names: Suchitepéquez
   geo:
     latitude: 14.4215982
@@ -1216,9 +1216,9 @@ SU:
     'no': Suchitepéquez
   comments:
   type: department
-TO:
+'08':
   name: Totonicapán
-  code: TO
+  code: '08'
   unofficial_names: Totonicapán
   geo:
     latitude: 14.910833
@@ -1276,9 +1276,9 @@ TO:
     'no': Totonicapán (departement)
   comments:
   type: department
-ZA:
+'19':
   name: Zacapa
-  code: ZA
+  code: '19'
   unofficial_names: Zacapa
   geo:
     latitude: 15.0784265


### PR DESCRIPTION
https://www.iso.org/obp/ui/#iso:code:3166:GT

> 2021-11-25 | Change of subdivision code from GT-AV to GT-16, GT-BV to GT-15, GT-CM to GT-04, GT-CQ to GT-20, GT-ES to GT-05, GT-GU to GT-01, GT-HU to GT-13, GT-IZ to GT-18, GT-JA to GT-21, GT-JU to GT-22, GT-PE to GT-17, GT-PR to GT-02, GT-QC to GT-14, GT-QZ to GT-09, GT-RE to GT-11, GT-SA to GT-03, GT-SM to GT-12, GT-SO to GT-07, GT-SR to GT-06, GT-SU to GT-10, GT-TO to GT-08, GT-ZA to GT-19; Update Code Source



