### PR TITLE
Adds the unofficial localized name of Bulgaria in Bulgarian

### DIFF
--- a/lib/countries/data/countries/BG.yaml
+++ b/lib/countries/data/countries/BG.yaml
@@ -53,6 +53,7 @@ BG:
   un_locode: BG
   unofficial_names:
   - Bulgaria
+  - България
   - Bulgarien
   - Bulgarie
   - ブルガリア


### PR DESCRIPTION
Adds the unofficial localized name of Bulgaria in Bulgarian (Cyrillic): `България`.