### PR TITLE
Update EE VAT from 20 to 22 (01/01/2024 change)

### DIFF
--- a/lib/countries/data/countries/EE.yaml
+++ b/lib/countries/data/countries/EE.yaml
@@ -51,7 +51,7 @@ EE:
   - Estonie
   - エストニア
   vat_rates:
-    standard: 20
+    standard: 22
     reduced:
     - 9
     super_reduced:


### PR DESCRIPTION
Hello,

Very small PR, the Estonia (EE) standard VAT rate changed from 20% to 22% on January 1st, 2024.
Here is the official accouncement: https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax#from-01012024
I noticed this because I checked the European VAT table (which is up to date): https://europa.eu/youreurope/business/taxation/vat/vat-rules-rates/index_en.htm
I noticed it was not matching what I had in my code (which is based on countries).

Thanks!
Adrien