### PR TITLE
Change VAT rates for CH valid from 2024-01-01

### DIFF
--- a/lib/countries/data/countries/CH.yaml
+++ b/lib/countries/data/countries/CH.yaml
@@ -61,10 +61,10 @@ CH:
   - スイス
   - Zwitserland
   vat_rates:
-    standard: 7.7
+    standard: 8.1
     reduced:
-    - 2.5
-    - 3.7
+    - 2.6
+    - 3.8
     super_reduced:
     parking:
   world_region: EMEA


### PR DESCRIPTION
Switzerland changed their VAT rates by beginning of 2024.

Reference:

https://www.estv.admin.ch/estv/en/home/value-added-tax/vat-rates-switzerland.html

<img width="269" alt="image" src="https://github.com/countries/countries/assets/1394828/31b9fe8c-d302-4935-b2d8-558671f0748b">
