### PR TITLE
Update PY.yaml

### DIFF
--- a/lib/countries/data/countries/PY.yaml
+++ b/lib/countries/data/countries/PY.yaml
@@ -39,7 +39,7 @@ PY:
   nationality: Paraguayan
   number: '600'
   postal_code: true
-  postal_code_format: "\\d{4}"
+  postal_code_format: "\\d{6}"
   region: Americas
   start_of_week: monday
   subregion: South America


### PR DESCRIPTION
Have been informed by customers, and cursory research verifies that Paraguay's postal code is 6 digits, not 4.