### PR TITLE
Add Great Britain as an Unofficial Name for GB

### DIFF
--- a/lib/countries/data/countries/GB.yaml
+++ b/lib/countries/data/countries/GB.yaml
@@ -71,6 +71,7 @@ GB:
   - Velká Británie
   - İngiltere
   - Великобританія
+  - Great Britain
   vat_rates:
     standard: 20
     reduced:


### PR DESCRIPTION
Hi,

Currently, using the `find_country_by_any_name` method does not return the record for "Great Britain" because the alternative that exists in unofficial names has an extra part, meaning that to be found you have to search using `ISO3166::Country.find_country_by_any_name(" Great Britain (UK)")`, but in my understanding it should also be returned in the simple name format, which would be `ISO3166::Country.find_country_by_any_name("Great Britain")`.