### PR TITLE
Update CD.yaml and CG.yaml

### DIFF
--- a/lib/countries/data/countries/CD.yaml
+++ b/lib/countries/data/countries/CD.yaml
@@ -58,4 +58,5 @@ CD:
   - Congo (The Democratic Republic Of The)
   - Democratic Republic of the Congo
   - Congo, Democratic Republic of
+  - Congo (Kinshasa)
   world_region: EMEA

--- a/lib/countries/data/countries/CG.yaml
+++ b/lib/countries/data/countries/CG.yaml
@@ -49,4 +49,5 @@ CG:
   - コンゴ共和国
   - Congo [Republiek]
   - Congo, Republic of
+  - Congo (Brazzaville)
   world_region: EMEA


### PR DESCRIPTION
Added unofficial names for Congo (Kinshasa) and Congo (Brazzaville).

### Details:
Added "Congo (Kinshasa)" as an unofficial name for Democratic Republic of the Congo (ISO 3166-1 alpha-2 code: CD).
Added "Congo (Brazzaville)" as an unofficial name for Republic of the Congo (ISO 3166-1 alpha-2 code: CG).

### Reason for Addition:
These names are also utilized by OpenFlights (https://openflights.org/data.php) to enhance compatibility and ease of integration with existing datasets and applications.