### PR TITLE
Correct Peterborough

### DIFF
--- a/lib/countries/data/subdivisions/GB.yaml
+++ b/lib/countries/data/subdivisions/GB.yaml
@@ -9029,7 +9029,7 @@ PTE:
     max_latitude: 52.6637708
     max_longitude: -0.1032429
   translations:
-    en: Peter
+    en: Peterborough
     af: Peterborough
     ar: بيتربرة
     bn: পিটারবার্গ


### PR DESCRIPTION
Corrects the translation name for "Peterborough"

https://en.wikipedia.org/wiki/Peterborough