### PR TITLE
Adds new #all_names_with_alpha_3_codes method and spec

### DIFF
--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -39,6 +39,13 @@ module ISO3166
       end.sort
     end
 
+    def all_names_with_alpha_3_codes(locale = 'en')
+      Country.all.map do |c|
+        lc = (c.translation(locale) || c.iso_short_name)
+        [lc.respond_to?(:html_safe) ? lc.html_safe : lc, c.alpha3]
+      end.sort
+    end
+
     def pluck(*attributes)
       all.map { |country| country.data.fetch_values(*attributes.map(&:to_s)) }
     end

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -468,6 +468,8 @@ describe ISO3166::Country do
       expect(countries).to be_an(Array)
       expect(countries.first[0]).to be_a(String)
       expect(countries.first[0]).to eq('Afghanistan')
+      expect(countries.first[1]).to be_a(String)
+      expect(countries.first[1]).to eq('AF')
       expect(countries.size).to eq(NUM_OF_COUNTRIES)
       expect(countries.any? { |pair| !pair[0].html_safe? }).to eq(false)
     end
@@ -479,6 +481,8 @@ describe ISO3166::Country do
       expect(countries).to be_an(Array)
       expect(countries.first[0]).to be_a(String)
       expect(countries.first[0]).to eq('Afganistán')
+      expect(countries.first[1]).to be_a(String)
+      expect(countries.first[1]).to eq('AF')
       expect(countries.size).to eq(NUM_OF_COUNTRIES)
     end
   end
@@ -489,6 +493,8 @@ describe ISO3166::Country do
       expect(countries).to be_an(Array)
       expect(countries.first[0]).to be_a(String)
       expect(countries.first[0]).to eq('Afghanistan')
+      expect(countries.first[1]).to be_a(String)
+      expect(countries.first[1]).to eq('AF')
       expect(countries.size).to eq(NUM_OF_COUNTRIES)
     end
 
@@ -499,6 +505,58 @@ describe ISO3166::Country do
       expect(countries).to be_an(Array)
       expect(countries.first[0]).to be_a(String)
       expect(countries.first[0]).to eq('Afganistán')
+      expect(countries.first[1]).to be_a(String)
+      expect(countries.first[1]).to eq('AF')
+      expect(countries.size).to eq(NUM_OF_COUNTRIES)
+    end
+  end
+
+  describe 'all_names_with_alpha_3_codes' do
+    require 'active_support/core_ext/string/output_safety'
+    it 'should return an alphabetized list of all country names with ISOCODE alpha3' do
+      countries = ISO3166::Country.all_names_with_alpha_3_codes
+      expect(countries).to be_an(Array)
+      expect(countries.first[0]).to be_a(String)
+      expect(countries.first[0]).to eq('Afghanistan')
+      expect(countries.first[1]).to be_a(String)
+      expect(countries.first[1]).to eq('AFG')
+      expect(countries.size).to eq(NUM_OF_COUNTRIES)
+      expect(countries.any? { |pair| !pair[0].html_safe? }).to eq(false)
+    end
+
+    it 'should return an alphabetized list of all country names translated to current locale with ISOCODE alpha3' do
+      ISO3166.configuration.locales = %i[es de en]
+
+      countries = ISO3166::Country.all_names_with_alpha_3_codes(:es)
+      expect(countries).to be_an(Array)
+      expect(countries.first[0]).to be_a(String)
+      expect(countries.first[0]).to eq('Afganistán')
+      expect(countries.first[1]).to be_a(String)
+      expect(countries.first[1]).to eq('AFG')
+      expect(countries.size).to eq(NUM_OF_COUNTRIES)
+    end
+  end
+
+  describe 'all_names_with_alpha_3_codes_without_active_support' do
+    it 'should return an alphabetized list of all country names with ISOCODE alpha3' do
+      countries = ISO3166::Country.all_names_with_alpha_3_codes
+      expect(countries).to be_an(Array)
+      expect(countries.first[0]).to be_a(String)
+      expect(countries.first[0]).to eq('Afghanistan')
+      expect(countries.first[1]).to be_a(String)
+      expect(countries.first[1]).to eq('AFG')
+      expect(countries.size).to eq(NUM_OF_COUNTRIES)
+    end
+
+    it 'should return an alphabetized list of all country names translated to current locale with ISOCODE alpha3' do
+      ISO3166.configuration.locales = %i[es de en]
+
+      countries = ISO3166::Country.all_names_with_alpha_3_codes(:es)
+      expect(countries).to be_an(Array)
+      expect(countries.first[0]).to be_a(String)
+      expect(countries.first[0]).to eq('Afganistán')
+      expect(countries.first[1]).to be_a(String)
+      expect(countries.first[1]).to eq('AFG')
       expect(countries.size).to eq(NUM_OF_COUNTRIES)
     end
   end


### PR DESCRIPTION
Hi! 

Really appreciate this gem. Had a need for a list of all countries with their alpha 3 codes and implemented in my app and then realized that it might make sense as a PR to here.

I implemented as a separate method from the existing `all_countries_with_codes` method, but I could also see it as an additional option to the existing method. 

```
 def all_names_with_codes(locale = 'en', code=alpha2)
   ... 
 end 
 
 ```

But I felt like a completely new method was probably the safest, even though theoretically adding an additional optional arg should not be risky. 

I also added a few additional expectations to the existing `all_countries_with_codes` specs to differentiate between its outputs and the new `all_countries_with_alpha_3_codes` outputs.

LMK if I need to make any changes. 