### PR TITLE
VAT rate for Finland changed to 25.5% as of 2024-09-01

### DIFF
--- a/lib/countries/data/countries/FI.yaml
+++ b/lib/countries/data/countries/FI.yaml
@@ -58,7 +58,7 @@ FI:
   - Finlandia
   - フィンランド
   vat_rates:
-    standard: 24
+    standard: 25.5
     reduced:
     - 10
     - 14


### PR DESCRIPTION
Finland changed their general VAT rate to 25.5 as of 2024-09-01.
Source: https://www.vero.fi/en/businesses-and-corporations/taxes-and-charges/vat/rates-of-vat/