### PR TITLE
Lazy load default locales

### DIFF
--- a/lib/countries/configuration.rb
+++ b/lib/countries/configuration.rb
@@ -10,7 +10,7 @@ module ISO3166
   end
 
   def self.reset
-    @configuration = nil
+    @configuration = Configuration.new
     Data.reset
   end
 

--- a/lib/countries/configuration.rb
+++ b/lib/countries/configuration.rb
@@ -10,7 +10,7 @@ module ISO3166
   end
 
   def self.reset
-    @configuration = Configuration.new
+    @configuration = nil
     Data.reset
   end
 
@@ -19,11 +19,15 @@ module ISO3166
   end
 
   class Configuration
-    attr_accessor :locales, :loaded_locales
+    attr_accessor :loaded_locales
+    attr_writer :locales
 
     def initialize
-      @locales = default_locales
       @loaded_locales = []
+    end
+
+    def locales
+      @locales ||= default_locales
     end
 
     # Enables the integration with the {Money}[https://github.com/RubyMoney/money] gem

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -4,10 +4,6 @@ require 'spec_helper'
 require 'i18n'
 
 describe 'ISO3166.configuration' do
-  it 'has a configuration' do
-    expect(ISO3166.configuration).to be_a ISO3166::Configuration
-  end
-
   it 'locales can be changed' do
     ISO3166.configuration.locales = [:es]
     ISO3166.configuration.locales << :de
@@ -56,5 +52,19 @@ describe 'ISO3166.configuration' do
     expect(ISO3166::Country.new('DE').translations.size).to eq 92
 
     expect(ISO3166.configuration.loaded_locales.size).to eq 92
+  end
+
+  context 'lazy load default locales' do
+    it 'does not load default locales during initialization' do
+      expect(I18n).to receive(:available_locales).never
+
+      ISO3166::Configuration.new
+    end
+
+    it 'loads default locales when calling #locales for the first time' do
+      expect(I18n).to receive(:available_locales).once.and_return([:test])
+
+      expect(ISO3166::Configuration.new.locales).to eq([:test])
+    end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -4,6 +4,10 @@ require 'spec_helper'
 require 'i18n'
 
 describe 'ISO3166.configuration' do
+  it 'has a configuration' do
+    expect(ISO3166.configuration).to be_a ISO3166::Configuration
+  end
+
   it 'locales can be changed' do
     ISO3166.configuration.locales = [:es]
     ISO3166.configuration.locales << :de


### PR DESCRIPTION
While analyzing my project's load times, I realized that the country initializer took almost a second:

```
start = Time.now;

ISO3166.configure do |config|
  config.locales = %i[en fr]
end

puts "Time elapsed #{(Time.now - start) * 1000} ms"
```

I was able to break it down to this line:

https://github.com/countries/countries/blob/master/lib/countries/configuration.rb#L25

In my project, `I18n.available_locales` is being set later during the initialization.
Because of that, the default `I18n.available_locales` are being loaded, which take some time to initialize.

While in most projects `I18n.available_locales` should be set earlier,
just lazily loading the default locales might be a good improvement anyway.

```
without lazy default locales: Time elapsed 965.10 ms

with lazy default locales: Time elapsed 0.006 ms
```
