### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,7 @@ Changing CHANGELOG entry format to use GitHub's generated release notes.
 - `Subdivision` now has a `type` attribute obtained from ISO3166-2 subdivision types. `type` is a _lowercase_ and _snake_cased_ string.
 - Adds `Country#subdivision_types` and `#humanized_subdivision_types` to list a country's subdivision types
 - Adds `Country#subdivisions_of_types(types)` to allow getting subdivisions of given type(s)
-- `Country#states` is now deprecated to avoid confusion (this method was just an alias to `#subdivisions` and retuns all subdivisions, regarless of type)
+- `Country#states` is now deprecated to avoid confusion (this method was just an alias to `#subdivisions` and returns all subdivisions, regardless of type)
 
 **Merged pull requests:**
 
@@ -428,7 +428,7 @@ Changing CHANGELOG entry format to use GitHub's generated release notes.
 - Add Ñuble region [\#598](https://github.com/hexorx/countries/pull/598) ([mbirman](https://github.com/mbirman))
 - Update Ireland Subdivision Formatting and Connacht and \(County\) Cork Data [\#596](https://github.com/hexorx/countries/pull/596) ([anastasiastowers](https://github.com/anastasiastowers))
 - Change the name of Macedonia to North Macedonia [\#585](https://github.com/hexorx/countries/pull/585) ([svetliomihailov](https://github.com/svetliomihailov))
-- Add Murica to United States unoffical names [\#577](https://github.com/hexorx/countries/pull/577) ([mikeyduece](https://github.com/mikeyduece))
+- Add Murica to United States unofficial names [\#577](https://github.com/hexorx/countries/pull/577) ([mikeyduece](https://github.com/mikeyduece))
 - Fix state codes from being returned as false [\#574](https://github.com/hexorx/countries/pull/574) ([akiellor](https://github.com/akiellor))
 - Update i18n\_data version [\#572](https://github.com/hexorx/countries/pull/572) ([tatarsky-v](https://github.com/tatarsky-v))
 - remove bin/console from gemspec [\#571](https://github.com/hexorx/countries/pull/571) ([patleb](https://github.com/patleb))
@@ -481,7 +481,7 @@ Changing CHANGELOG entry format to use GitHub's generated release notes.
 - Memoize subdivision YAML loading [\#510](https://github.com/hexorx/countries/pull/510) ([mdehoog](https://github.com/mdehoog))
 - Update CZ country name [\#509](https://github.com/hexorx/countries/pull/509) ([minvs1](https://github.com/minvs1))
 - Add Ukraine vat rates [\#507](https://github.com/hexorx/countries/pull/507) ([jgrau](https://github.com/jgrau))
-- Corrected swedish transation for GB [\#505](https://github.com/hexorx/countries/pull/505) ([pidu](https://github.com/pidu))
+- Corrected swedish translation for GB [\#505](https://github.com/hexorx/countries/pull/505) ([pidu](https://github.com/pidu))
 - Remove empty :geo key and misspelled latitude [\#504](https://github.com/hexorx/countries/pull/504) ([normancapule](https://github.com/normancapule))
 - Update README.markdown [\#502](https://github.com/hexorx/countries/pull/502) ([gssbzn](https://github.com/gssbzn))
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Release 4.2.0 introduced changes to name attributes and finders and deprecated s
 
 The 5.0 release removed these deprecated methods and also removed support for Ruby 2.5 and 2.6
 
-Plase see [UPGRADE.md](../master/UPGRADE.md) for more information
+Please see [UPGRADE.md](../master/UPGRADE.md) for more information
 
 ## Attribute-Based Finder Methods
 
@@ -243,7 +243,7 @@ c.distance_unit # => "MI"
 ISO3166::Country.pluck(:alpha2, :iso_short_name) # => [["AD", "Andorra"], ["AE", "United Arab Emirates"], ...
 ```
 
-`.collect_countries_with` allows to collect various countries' informations using any valid method and query value:
+`.collect_countries_with` allows to collect various countries' information using any valid method and query value:
 ```ruby
 > ISO3166::Country.collect_countries_with("VR",:subdivisions,:common_name)
  => ["Italy", "Monaco"]

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -113,7 +113,7 @@ module ISO3166
       translation('en')
     end
 
-    # @return [Array<String>] TThe list of names for this Country, in this Country's locales.
+    # @return [Array<String>] The list of names for this Country, in this Country's locales.
     def local_names
       ISO3166.configuration.locales = (ISO3166.configuration.locales + languages.map(&:to_sym)).uniq
       reload

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -1231,7 +1231,7 @@ describe ISO3166::Country do
       expect(ISO3166::Country('us')).to eq country
     end
 
-    it 'should return country if not convertable input given' do
+    it 'should return country if not convertible input given' do
       expect do
         ISO3166::Country(42)
       end.to raise_error(TypeError, /can't convert ([A-z]+) into ISO3166::Country/)

--- a/spec/perf_spec.rb
+++ b/spec/perf_spec.rb
@@ -60,7 +60,7 @@ describe ISO3166::Data, perf: true, order: :defined do
     report.pretty_print(to_file: 'tmp/all_locales.txt')
   end
 
-  it 'loades a specfic country quickly' do
+  it 'loades a specific country quickly' do
     codes = Dir['lib/countries/data/countries/*.yaml'].map { |x| File.basename(x, File.extname(x)) }.uniq
     Benchmark.bmbm do |bm|
       bm.report('find_by_alpha2') do


### PR DESCRIPTION
Found and fixed via `codespell`

```
codespell **/*.rb -w -L fo,te
codespell **/*.md -w -L fo,te
```

Manual fixes:
- transation => translation
- Plase => Please