### PR TITLE
Add nanp_prefix to MP

### DIFF
--- a/lib/countries/data/countries/MP.yaml
+++ b/lib/countries/data/countries/MP.yaml
@@ -31,6 +31,8 @@ MP:
   languages_spoken:
   - en
   - ch
+  nanp_prefix:
+  - 1670
   national_destination_code_lengths:
   - 3
   national_number_lengths:


### PR DESCRIPTION
Source: https://www.countrycodeguide.com/oceania/northern-mariana-islands