### PR TITLE
Add nanp_prefix to VI

### DIFF
--- a/lib/countries/data/countries/VI.yaml
+++ b/lib/countries/data/countries/VI.yaml
@@ -29,6 +29,8 @@ VI:
   - en
   languages_spoken:
   - en
+  nanp_prefix:
+  - 1340
   national_destination_code_lengths:
   - 3
   national_number_lengths:


### PR DESCRIPTION
Source: https://www.countrycodeguide.com/north-america/us-virgin-islands-