### PR TITLE
Add nanp_prefix to DO

### DIFF
--- a/lib/countries/data/countries/DO.yaml
+++ b/lib/countries/data/countries/DO.yaml
@@ -29,6 +29,8 @@ DO:
   - es
   languages_spoken:
   - es
+  nanp_prefix:
+  - 1809
   national_destination_code_lengths:
   - 3
   national_number_lengths:


### PR DESCRIPTION
Source: https://www.countrycodeguide.com/north-america/dominican-republic