### PR TITLE
Experiment with symbol-keyed translation hashes to reduce string allocations

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -108,8 +108,15 @@ module ISO3166
 
     # @param locale [String] The locale to use for translations.
     # @return [String] the name of this Country in the selected locale.
-    def translation(locale = 'en')
-      data['translations'][locale.to_s.downcase]
+    def translation(locale = :en)
+      case locale
+      when Symbol
+        locale = locale.downcase
+      when String
+        locale = locale.downcase if locale.match?(/[A-Z]/)
+        locale = locale.to_sym
+      end
+      data['translations'][locale]
     end
 
     # @return [String] the “common name” of this Country in English.

--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -18,7 +18,12 @@ module ISO3166
 
   module CountryClassMethods
     def new(country_data)
-      super if country_data.is_a?(Hash) || codes.include?(country_data.to_s.upcase)
+      unless country_data.is_a?(Hash)
+        country_data = country_data.to_s if country_data.is_a?(Symbol)
+        country_data = country_data.upcase if country_data.match?(/[a-z]/)
+      end
+
+      super if country_data.is_a?(Hash) || codes.include?(country_data)
     end
 
     def codes
@@ -32,7 +37,7 @@ module ISO3166
 
     alias countries all
 
-    def all_names_with_codes(locale = 'en')
+    def all_names_with_codes(locale = :en)
       Country.all.map do |c|
         lc = c.translation(locale) || c.iso_short_name
         [lc.respond_to?('html_safe') ? lc.html_safe : lc, c.alpha2]
@@ -43,12 +48,14 @@ module ISO3166
       all.map { |country| country.data.fetch_values(*attributes.map(&:to_s)) }
     end
 
-    def all_translated(locale = 'en')
+    def all_translated(locale = :en)
       translations(locale).values
     end
 
-    def translations(locale = 'en')
-      locale = locale.downcase.freeze
+    def translations(locale = :en)
+      locale = locale.downcase if locale.match?(/[A-Z]/)
+      locale = locale.to_sym if locale.is_a?(String)
+
       file_path = ISO3166::Data.datafile_path(%W[locales #{locale}.json])
       translations = JSON.parse(File.read(file_path))
 

--- a/lib/countries/country/country_subdivision_methods.rb
+++ b/lib/countries/country/country_subdivision_methods.rb
@@ -51,13 +51,13 @@ module ISO3166
 
     # @param locale [String] The locale to use for translations.
     # @return [Array<Array>] This Country's subdivision pairs of names and codes.
-    def subdivision_names_with_codes(locale = 'en')
+    def subdivision_names_with_codes(locale = :en)
       subdivisions.map { |k, v| [v.translations[locale] || v.name, k] }
     end
 
     # @param locale [String] The locale to use for translations.
     # @return [Array<String>] A list of subdivision names for this country.
-    def subdivision_names(locale = 'en')
+    def subdivision_names(locale = :en)
       subdivisions.map { |_k, v| v.translations[locale] || v.name }
     end
 

--- a/lib/countries/country/finder_methods.rb
+++ b/lib/countries/country/finder_methods.rb
@@ -6,7 +6,10 @@ module ISO3166
     SEARCH_TERM_FILTER_REGEX = /\(|\)|\[\]|,/
 
     def search(query)
-      country = new(query.to_s.upcase)
+      query = query.to_s if query.is_a?(Symbol)
+      query = query.upcase if query.match?(/[a-z]/)
+
+      country = new(query)
       country&.valid? ? country : nil
     end
 

--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -14,7 +14,10 @@ module ISO3166
     @subdivisions = {}
 
     def initialize(alpha2)
-      @alpha2 = alpha2.to_s.upcase
+      alpha2 = alpha2.to_s if alpha2.is_a?(Symbol)
+      alpha2 = alpha2.upcase if alpha2.match?(/[a-z]/)
+
+      @alpha2 = alpha2
     end
 
     def call
@@ -27,8 +30,10 @@ module ISO3166
       # Overriding an existing country will also remove it from the internal management of translations.
       def register(data)
         alpha2 = data[:alpha2].upcase
-        @registered_data[alpha2] = deep_stringify_keys(data)
-        @registered_data[alpha2]['translations'] = Translations.new.merge(data['translations'] || {})
+        @registered_data[alpha2] = deep_stringify_keys(data.except('translations', :translations))
+        translations = data['translations'] || data[:translations] || {}
+        translations.transform_keys!(&:to_sym)
+        @registered_data[alpha2]['translations'] = Translations.new.merge(translations)
         @cache = cache.merge(@registered_data)
       end
 

--- a/lib/countries/data/locales_methods.rb
+++ b/lib/countries/data/locales_methods.rb
@@ -13,11 +13,11 @@ module ISO3166
     end
 
     def requested_locales
-      ISO3166.configuration.locales.map { |locale| locale.to_s.downcase }
+      ISO3166.configuration.locales.map { |locale| locale.match?(/[A-Z]/) ? locale.downcase : locale }
     end
 
     def loaded_locales
-      ISO3166.configuration.loaded_locales.map { |locale| locale.to_s.downcase }
+      ISO3166.configuration.loaded_locales.map { |locale| locale.match?(/[A-Z]/) ? locale.downcase : locale }
     end
   end
 end

--- a/lib/countries/data/subdivision_methods.rb
+++ b/lib/countries/data/subdivision_methods.rb
@@ -5,8 +5,10 @@ module ISO3166
     def subdivision_data(alpha2)
       data = load_data_for_alpha2(alpha2)
       locales = ISO3166.configuration.locales.map(&:to_s)
-
-      data.each_value { |subdivision| subdivision['translations'] = subdivision['translations'].slice(*locales) }
+      data.each_value do |subdivision|
+        subdivision['translations'] = subdivision['translations'].slice(*locales)
+                                                                 .transform_keys(&:to_sym)
+      end
 
       data
     end

--- a/lib/countries/translations.rb
+++ b/lib/countries/translations.rb
@@ -5,9 +5,14 @@ module ISO3166
   #
   # E.g. if a country has translations for +pt+, and the user looks up +pt-br+ fallback
   # to +pt+ to prevent from showing nil values
+  #
+  # Also allows "indifferent access" to the hash, so you can use strings or symbols
   class Translations < Hash
     def [](locale)
-      super || super(locale.to_s.sub(/-.*/, ''))
+      translations = locale.is_a?(String) ? super(locale.to_sym) : super
+      return translations if translations
+
+      super(locale.to_s.sub(/-.*/, '').to_sym)
     end
   end
 end

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -61,7 +61,6 @@ describe ISO3166::Country do
   end
 
   it 'should return translations' do
-    expect(country.translations).to be
     expect(country.translations['en']).to eq('United States')
   end
 
@@ -342,6 +341,17 @@ describe ISO3166::Country do
       expect(subdivisions).to be_an(Array)
       expect(subdivisions.first[0]).to be_a(String)
       expect(subdivisions.size).to eq(27)
+      expect(subdivisions.first[0]).to eq('Alejandría')
+    end
+
+    it 'falls back to the base subdivision name if the translation is missing' do
+      ISO3166.configuration.locales = %i[af]
+      ISO3166::Data.reset
+
+      subdivisions = ISO3166::Country.search('EG').subdivision_names_with_codes(:af)
+      expect(subdivisions).to be_an(Array)
+      expect(subdivisions.first[0]).to be_a(String)
+      expect(subdivisions.size).to eq(27)
       expect(subdivisions.first[0]).to eq('Al Iskandariyah')
     end
   end
@@ -360,6 +370,17 @@ describe ISO3166::Country do
       ISO3166::Data.reset
 
       subdivisions = ISO3166::Country.search('EG').subdivision_names(:es)
+      expect(subdivisions).to be_an(Array)
+      expect(subdivisions.first).to be_a(String)
+      expect(subdivisions.size).to eq(27)
+      expect(subdivisions.first).to eq('Alejandría')
+    end
+
+    it 'falls back to the base subdivision name if the translation is missing' do
+      ISO3166.configuration.locales = %i[af]
+      ISO3166::Data.reset
+
+      subdivisions = ISO3166::Country.search('EG').subdivision_names(:af)
       expect(subdivisions).to be_an(Array)
       expect(subdivisions.first).to be_a(String)
       expect(subdivisions.size).to eq(27)

--- a/spec/subdivision_spec.rb
+++ b/spec/subdivision_spec.rb
@@ -35,8 +35,8 @@ describe ISO3166::Subdivision do
   describe 'code_with_translations' do
     before { ISO3166.configuration.locales = %i[en pt] }
     it 'returns a hash' do
-      expect(ISO3166::Country.new('IT').subdivisions['NA'].code_with_translations).to eq({ 'NA' => { 'en' => 'Naples',
-                                                                                                     'pt' => 'Nápoles' } })
+      expect(ISO3166::Country.new('IT').subdivisions['NA'].code_with_translations).to eq({ 'NA' => { en: 'Naples',
+                                                                                                     pt: 'Nápoles' } })
     end
   end
 end


### PR DESCRIPTION
Trying to fix #872 

This PR has potentially breaking changes.

Change the translation arrays in both countries and subdivisions to use Symbol keys instead of String keys and update code to minimize allocations when sanitizing and/or downcasing locale strings.

Access to translation arrays and calls to the translation methods should still work with both String and Symbol locales, but the actual arrays will use Symbol keys, and some methods will return these arrays, which can be a breaking change.