### PR TITLE
fix(data): DK `address_format`

### DIFF
--- a/lib/countries/data/countries/DK.yaml
+++ b/lib/countries/data/countries/DK.yaml
@@ -4,7 +4,6 @@ DK:
     {{recipient}}
     {{street}}
     {{postalcode}} {{city}}
-    {{region}}
     {{country}}
   alpha2: DK
   alpha3: DNK


### PR DESCRIPTION
The address format for Denmark was including `region`. This is not used in Danish addresses.

I ran into this whilst trying to validate address data in our database, ensuring we had all required components for rendering addresses.

Reference:

https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/dnkEn.pdf

https://www.postnord.dk/en/preparations/practical-information-about-letters-and-envelopes/addressing/

Additional reference: I live in Denmark and you never see any "region" data in an address. It's not relevant. It'd be like writing "Southern California" as a region for a US address.