### PR TITLE
fix: currency of Curacao and Saint Maarten

### DIFF
--- a/lib/countries/data/countries/CW.yaml
+++ b/lib/countries/data/countries/CW.yaml
@@ -4,7 +4,7 @@ CW:
   alpha3: CUW
   continent: North America
   country_code: '599'
-  currency_code: ANG
+  currency_code: XCG
   distance_unit: KM
   gec: UC
   geo:

--- a/lib/countries/data/countries/SX.yaml
+++ b/lib/countries/data/countries/SX.yaml
@@ -4,7 +4,7 @@ SX:
   alpha3: SXM
   continent: North America
   country_code: '1'
-  currency_code: ANG
+  currency_code: XCG
   distance_unit: KM
   gec: NN
   geo:


### PR DESCRIPTION
The ANG currency was withdrawn as of 2025-03 in Curacao and Saint Maarten.