### PR TITLE
Fix SG - Singapore country name in pt-BR

### DIFF
--- a/lib/countries/data/translations/countries-pt_BR.yaml
+++ b/lib/countries/data/translations/countries-pt_BR.yaml
@@ -200,7 +200,7 @@ SB: Ilhas Salomão
 SC: Seychelles
 SD: Sudão
 SE: Suécia
-SG: Cingapura
+SG: Singapura
 SH: Santa Helena, Ascensão e Tristão da Cunha
 SI: Eslovênia
 SJ: Svalbard e a Ilha de Jan Mayen


### PR DESCRIPTION
Official Singapore website: https://www.mfa.gov.sg/Overseas-Mission/Brasilia/BP/Brasilia-BP/Mission-Updates/2015/12/Emb_new_port_29122015

**pt-BR**
> A grafia do nome do nosso país finalmente será unificada. Até agora, todos os dicionários aceitavam as duas grafias. No entanto, o Acordo Ortográfico de 1990 (que entrou em vigor apenas em 2009 e será obrigatório a partir de 1º de janeiro de 2016) determina a adoção da grafia "Singapura", pondo fim a uma dúvida comum entre os brasileiros. Então, a partir de 1º de janeiro de 2016, somente uma forma será correta: "Singapura"!

**en**
> The spelling of our country's name will finally be standardized. Until now, all dictionaries accepted both spellings. However, the Orthographic Agreement of 1990 (which only came into effect in 2009 and will be mandatory starting January 1, 2016) mandates the adoption of the spelling "Singapura", putting an end to a common doubt among Brazilians. So, starting January 1, 2016, only one form will be correct: "Singapura"!