### PR TITLE
Correct ZA province name

### DIFF
--- a/lib/countries/data/subdivisions/ZA.yaml
+++ b/lib/countries/data/subdivisions/ZA.yaml
@@ -479,7 +479,7 @@ NC:
     gl: Cabo Setentrional
   type: province
 NW:
-  name: North-West
+  name: North West
   code: NW
   unofficial_names:
   - North-West


### PR DESCRIPTION
The official name of the province is `North West`, not `North-West`.

Source: https://www.gov.za/provinces