### PR TITLE
Changes the short name of DRPK and ROK

### DIFF
--- a/lib/countries/data/countries/KP.yaml
+++ b/lib/countries/data/countries/KP.yaml
@@ -24,7 +24,7 @@ KP:
   international_prefix: '00'
   ioc: PRK
   iso_long_name: The Democratic People's Republic of Korea
-  iso_short_name: Korea (Democratic People's Republic of)
+  iso_short_name: North Korea (DPRK)
   languages_official:
   - ko
   languages_spoken:

--- a/lib/countries/data/countries/KR.yaml
+++ b/lib/countries/data/countries/KR.yaml
@@ -31,7 +31,7 @@ KR:
   international_prefix: '001'
   ioc: KOR
   iso_long_name: The Republic of Korea
-  iso_short_name: Korea (Republic of)
+  iso_short_name: South Korea (ROK)
   languages_official:
   - ko
   languages_spoken:


### PR DESCRIPTION
In lists the short name of both the Democratic People's Republic of Korea (DRPK) and The Republic of Korea (ROK) are too long to be visible making them confusing to read. A client requested we change the short names to "North Korea (DRPK)" and "South Korea (ROK)" for clarity's sake.

https://app.shortcut.com/huntress/story/161283/list-north-and-south-korea-differently-for-clarity