### PR TITLE
fix: add guard clause to check if matches is nil

### DIFF
--- a/lib/countries/country/finder_methods.rb
+++ b/lib/countries/country/finder_methods.rb
@@ -46,12 +46,12 @@ module ISO3166
     # :reek:BooleanParameter
     def respond_to_missing?(method_name, include_private = false)
       matches = method_name.to_s.match(FIND_BY_REGEX)
+
+      return super unless matches
+
       method = matches[3]
-      if matches && method
-        instance_methods.include?(method.to_sym)
-      else
-        super
-      end
+
+      instance_methods.include?(method.to_sym) if method
     end
 
     protected

--- a/lib/countries/country/finder_methods.rb
+++ b/lib/countries/country/finder_methods.rb
@@ -46,12 +46,11 @@ module ISO3166
     # :reek:BooleanParameter
     def respond_to_missing?(method_name, include_private = false)
       matches = method_name.to_s.match(FIND_BY_REGEX)
-
-      return super unless matches
+      return super unless matches && matches[3]
 
       method = matches[3]
 
-      instance_methods.include?(method.to_sym) if method
+      instance_methods.include?(method.to_sym)
     end
 
     protected

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -11,6 +11,10 @@ describe ISO3166::Country do
 
   let(:country) { ISO3166::Country.search('US') }
 
+  it 'handles respond_to_missing values' do
+    expect(described_class.respond_to?(:arr)).not_to be_nil
+  end
+
   it 'allows to create a country object from a symbol representation of the alpha2 code' do
     country = described_class.new(:us)
     expect(country.data).not_to be_nil


### PR DESCRIPTION
Hi,

After the release of Country version 8, certain parts of our application began breaking with the following error:

```
   NoMethodError:
     undefined method `[]' for nil
   # ./lib/countries/country/finder_methods.rb:49:in `respond_to_missing?'
```

We traced the issue to the `matches` variable being `nil` and still being accessed with an index in `finder_methods`. To reproduce this, I’ve added a spec that demonstrates the failure.

This PR fixes the issue by adding a guard clause to return early, if `matches` is `nil` preventing the `NoMethodError`.

### Our Usage
<hr>

The behavior surfaced when using the gem in combination with the CanCanCan authorization gem. Internally, CanCanCan calls `respond_to?(:arr)` on the `ISO3166::Country` object. That call triggered the error shown above.

If this fix isn’t appropriate or there's a preferred way of doing it, kindly comment :)


