### PR TITLE
fix: change french name of France subdivisions

### DIFF
--- a/lib/countries/data/subdivisions/FR.yaml
+++ b/lib/countries/data/subdivisions/FR.yaml
@@ -8430,7 +8430,7 @@ NAQ:
     sl: Nova Akvitanija
   type: metropolitan_region
 NC:
-  name: New Caledonia
+  name: Nouvelle-Calédonie
   code: NC
   unofficial_names:
   - Nouvelle-Calédonie

--- a/lib/countries/data/translations/countries-fr.yaml
+++ b/lib/countries/data/translations/countries-fr.yaml
@@ -52,6 +52,7 @@ CL: Chili
 CM: Cameroun
 CN: Chine
 CO: Colombie
+CP: Clipperton
 CR: Costa Rica
 CU: Cuba
 CV: Cap-Vert


### PR DESCRIPTION
In file `lib/countries/data/subdivisions/FR.yaml` : 
- use French name `Nouvelle-Calédonie` for `New Caledonia` as subdivision of France country

In file `lib/countries/data/translations/countries-fr.yaml` : 
- add `CP: Clipperton` because there is also `TF: Terres australes françaises` in the same file