### PR TITLE
Update Estonia standard VAT from 22% to 24% (July 1st 2025 change) 

### DIFF
--- a/lib/countries/data/countries/EE.yaml
+++ b/lib/countries/data/countries/EE.yaml
@@ -52,8 +52,9 @@ EE:
   - Estonie
   - エストニア
   vat_rates:
-    standard: 22
+    standard: 24
     reduced:
+    - 13
     - 9
   vehicle_registration_code: EST
   world_region: EMEA


### PR DESCRIPTION
Like the [last time](https://github.com/countries/countries/pull/849) ^^
Increased VAT rate from 22 to 24 on July 2025: https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax#from-01072025
Also I added a 13% reduced rate which increased from 9 to 13 on Jan 1st 2025: https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax#from-01012025 (and there's another reduced rate which went from 5 to 9 so I left 9 and 13).



