### PR TITLE
Change Vatican nationality to Vatican Citizen over Italian

### DIFF
--- a/lib/countries/data/countries/VA.yaml
+++ b/lib/countries/data/countries/VA.yaml
@@ -37,7 +37,7 @@ VA:
   national_number_lengths:
   - 9
   national_prefix: None
-  nationality: Italian
+  nationality: Vatican Citizen
   number: '336'
   postal_code: true
   postal_code_format: '00120'

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -1304,6 +1304,22 @@ describe ISO3166::Country do
     end
   end
 
+  describe 'Searching by Nationality' do
+     it 'should return Italy for Italian' do
+      expect(ISO3166::Country.find_country_by_nationality('Italian').alpha2).to eq 'IT'
+    end
+    it 'should return Pakistan for Pakistani' do
+      expect(ISO3166::Country.find_country_by_nationality('Pakistani').alpha2).to eq 'PK' 
+    end
+    it 'should return United States for American' do
+      expect(ISO3166::Country.find_country_by_nationality('American').alpha2).to eq 'US'
+    end
+
+    it 'should return Netherlands for Dutch' do
+      expect(ISO3166::Country.find_country_by_nationality('Dutch').alpha2).to eq 'NL'
+    end
+  end
+
   describe 'Added country names to search by' do
     it 'should return country code for Democratic Republic of the Congo' do
       expect(ISO3166::Country.find_country_by_unofficial_names('Democratic Republic of the Congo').alpha2).to eq 'CD'


### PR DESCRIPTION
When searching by nationality, it seems far more likely that "Italian" should return IT over VA

```ruby
ISO3166::Country.find_country_by_nationality("Italian").alpha2
"VA"
```

While those born within the Vatican's walls are granted Italian citizenship, when searching by Nationality it's statistically far more viable that we'd be looking for "Italy" over "Vatican City"