### PR TITLE
Update Romania standard VAT from 19% to 21% + single reduced rate to 11% (Aug 1st 2025 change)

### DIFF
--- a/lib/countries/data/countries/RO.yaml
+++ b/lib/countries/data/countries/RO.yaml
@@ -58,10 +58,9 @@ RO:
   - ルーマニア
   - Roemenië
   vat_rates:
-    standard: 19
+    standard: 21
     reduced:
-    - 5
-    - 9
+    - 11
     super_reduced:
     parking:
   vehicle_registration_code: RO


### PR DESCRIPTION
And here is another one :)
https://www.asd-int.com/en/romania-vat-will-officially-rise-to-21-from-1-august-2025/