### PR TITLE
Fix misuse of File.join with nested array

### DIFF
--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -75,7 +75,7 @@ module ISO3166
       end
 
       def datafile_path(file_array)
-        File.join([@cache_dir] + file_array)
+        File.join(*(@cache_dir + file_array))
       end
 
       private


### PR DESCRIPTION
As documented, `File.join` expects individual path components. For improved security (reliable path traversal detection) [Zen by Aikido for Ruby](https://github.com/AikidoSec/firewall-ruby) enforces this documented usage by default.

Because `@cache_dir` is an array, wrapping it in an array causes `File.join` to be called with a nested array argument.

This change corrects the usage of `File.join` by not wrapping `@cache_dir` in an array and using the `*` splat operator to pass each path component individually, ensuring that the `countries` gem works correctly in applications protected by [Zen by Aikido](https://www.aikido.dev/zen).