### PR TITLE
[~] avoid redundant objects allocations

### DIFF
--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -26,6 +26,16 @@ module ISO3166
       super if codes.include?(country_code)
     end
 
+    def cached_instance(country_data)
+      @_country_instance_cache ||= {}
+      alpha2 = country_data['alpha2']
+      @_country_instance_cache[alpha2] ||= new(country_data)
+    end
+
+    def reset_country_cache
+      @_country_instance_cache = {}
+    end
+
     # :reek:UtilityFunction
     def codes
       ISO3166::Data.codes

--- a/lib/countries/country/finder_methods.rb
+++ b/lib/countries/country/finder_methods.rb
@@ -4,6 +4,7 @@ module ISO3166
   module CountryFinderMethods
     FIND_BY_REGEX = /^find_(all_)?(country_|countries_)?by_(.+)/
     SEARCH_TERM_FILTER_REGEX = /\(|\)|\[\]|,/
+    ANY_NAME_ATTRIBUTES = %w[iso_long_name iso_short_name unofficial_names translated_names].freeze
 
     # :reek:FeatureEnvy
     def search(query)
@@ -23,10 +24,15 @@ module ISO3166
       attributes, lookup_value = parse_attributes(attribute, val)
 
       ISO3166::Data.cache.select do |_k, value|
-        country = Country.new(value)
+        country = Country.cached_instance(value)
         attributes.any? do |attr|
-          Array(country.send(attr)).any? do |attr_value|
-            lookup_value === cached(attr_value) { parse_value(attr_value) }
+          attr_value = value[attr] || country.send(attr)
+          if attr_value.is_a?(Array)
+            attr_value.any? do |v|
+              v && lookup_value === cached(v) { parse_value(v) }
+            end
+          else
+            attr_value && lookup_value === cached(attr_value) { parse_value(attr_value) }
           end
         end
       end
@@ -66,8 +72,7 @@ module ISO3166
       raise "Invalid attribute name '#{attribute}'" unless searchable_attribute?(attribute.to_sym)
 
       attribute = attribute.to_s
-      attributes = Array(attribute)
-      attributes = %w[iso_long_name iso_short_name unofficial_names translated_names] if attribute == 'any_name'
+      attributes = attribute == 'any_name' ? ANY_NAME_ATTRIBUTES : [attribute]
 
       [attributes, parse_value(val)]
     end
@@ -84,7 +89,7 @@ module ISO3166
     end
 
     def searchable_attributes
-      instance_methods - UNSEARCHABLE_METHODS + %i[any_name]
+      @_searchable_attributes ||= (instance_methods - UNSEARCHABLE_METHODS + %i[any_name]).freeze
     end
   end
 end

--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -55,6 +55,7 @@ module ISO3166
           @subdivisions = {}
           @registered_data = {}
           ISO3166.configuration.loaded_locales = []
+          ISO3166::Country.reset_country_cache
         end
       end
 


### PR DESCRIPTION
Optimize finder methods to reduce object allocations. Especially helpful on "hot" code.

   ### Summary

   Reduces memory allocations in find_country_by_any_name and related finder
   methods by 98.6% (from 1,530 to 21 objects per call).

   ### Key Changes

     - Country instance caching - Cache and reuse Country objects by alpha2 code
     - Direct data hash access - Access value[attr] directly instead of calling methods that allocate new arrays
     - Cache searchable attributes - Memoize the searchable attributes array
     - Optimize array handling - Use direct array literals and frozen constants
     - Skip nil values - Prevent nil matching in array comparisons

   ### Testing

     - All 269 tests pass ✓
     - No breaking changes

   ### Verification
```ruby
$LOAD_PATH.unshift(File.expand_path('lib'))
require 'memory_profiler'
require 'countries'

ISO3166::Country.find_country_by_any_name('United States')

report = MemoryProfiler.report do
  100.times { ISO3166::Country.find_country_by_any_name('United States') }
end

puts "Allocated: #{report.total_allocated} objects"
puts "Avg: #{report.total_allocated / 100} objects per call"
```
   Expected output: ~21 objects per call (vs ~1,530 before optimization)
