### PR TITLE
fix(country): Add unofficial name "La Réunion" for Réunion (RE)

### DIFF
--- a/lib/countries/data/countries/RE.yaml
+++ b/lib/countries/data/countries/RE.yaml
@@ -46,6 +46,7 @@ RE:
   un_locode: RE
   un_member: false
   unofficial_names:
+  - La Réunion
   - Réunion
   - Reunión
   - Reunion


### PR DESCRIPTION
**Request**
Add the unofficial name "La Réunion" to the Réunion (RE) country data so the territory can be matched when users search or type this common French form.

**Context**
We needed this because Google’s Places Autocomplete (or similar) returns "La Réunion" as the country name.
Without this unofficial name in the gem, we couldn’t match the Google result to the Réunion country record.

```ruby
# Returns nil (doesn't work)
ISO3166::Country.find_country_by_any_name("la réunion")

# Returns country (works)
ISO3166::Country.find_country_by_any_name("réunion")
```

**Impact**
Changed in `lib/countries/data/countries/RE.yaml`
```ruby
  unofficial_names:
  - La Réunion # added
  - Réunion
  - Reunión
  - Reunion
  - レユニオン
```