### PR TITLE
Add unofficial names for Canadian subdivisions (PEI, NWT, PQ)

### DIFF
--- a/lib/countries/data/subdivisions/CA.yaml
+++ b/lib/countries/data/subdivisions/CA.yaml
@@ -541,6 +541,7 @@ NT:
   name: Northwest Territories
   code: NT
   unofficial_names:
+  - NWT
   - Territoires du Nord-Ouest
   geo:
     latitude: 64.8255441
@@ -807,6 +808,7 @@ PE:
   name: Prince Edward Island
   code: PE
   unofficial_names:
+  - PEI
   - Île-du-Prince-Édouard
   geo:
     latitude: 46.510712
@@ -895,6 +897,7 @@ QC:
   name: Quebec
   code: QC
   unofficial_names:
+  - PQ
   - Québec
   geo:
     latitude: 52.9399159


### PR DESCRIPTION
Add missing unofficial names for Canadian provinces and territories

## PEI (Prince Edward Island)
As the acronym for Canada's smallest province, PEI is arguably used more frequently than the full name itself. PEI is widely used by Canadians to refer to the province.

## NWT (Northwest Territories)
The NWT alias is essential because the full name "Northwest Territories" is often viewed as a descriptive phrase rather than a singular proper noun by search algorithms. NWT is also widely used by Canadians.

## PQ (Province du Québec)
While "QC" is the modern ISO postal abbreviation, PQ carries significant historical and cultural weight. It stems from the French Province du Québec and was the standard abbreviation for decades. You will still find "PQ" scattered across legacy databases, older legal documents, and vintage mapping sets.