### PR TITLE
Fix national_number_length values for MW, MR, CD, and CI

### DIFF
--- a/lib/countries/data/countries/CD.yaml
+++ b/lib/countries/data/countries/CD.yaml
@@ -41,7 +41,7 @@ CD:
   national_destination_code_lengths:
   - 2
   national_number_lengths:
-  - 8
+  - 9
   national_prefix: None
   nationality: Congolese
   number: '180'

--- a/lib/countries/data/countries/CI.yaml
+++ b/lib/countries/data/countries/CI.yaml
@@ -32,7 +32,7 @@ CI:
   national_destination_code_lengths:
   - 2
   national_number_lengths:
-  - 8
+  - 10
   national_prefix: '0'
   nationality: Ivorian
   number: '384'

--- a/lib/countries/data/countries/MR.yaml
+++ b/lib/countries/data/countries/MR.yaml
@@ -34,7 +34,7 @@ MR:
   national_destination_code_lengths:
   - 2
   national_number_lengths:
-  - 7
+  - 8
   national_prefix: '0'
   nationality: Mauritanian
   number: '478'

--- a/lib/countries/data/countries/MW.yaml
+++ b/lib/countries/data/countries/MW.yaml
@@ -34,7 +34,7 @@ MW:
   national_destination_code_lengths:
   - 2
   national_number_lengths:
-  - 8
+  - 9
   national_prefix: None
   nationality: Malawian
   number: '454'


### PR DESCRIPTION
Fix #953 
This PR updates the `national_number_length` values in the YAML files for:

- MW (Malawi)
- MR (Mauritania)
- CD (Democratic Republic of the Congo)
- CI (Côte d’Ivoire)