### PR TITLE
Update national number lengths for Somalia

### DIFF
--- a/lib/countries/data/countries/SO.yaml
+++ b/lib/countries/data/countries/SO.yaml
@@ -34,8 +34,7 @@ SO:
   national_destination_code_lengths:
   - 2
   national_number_lengths:
-  - 7
-  - 8
+  - 9
   national_prefix: None
   nationality: Somali
   number: '706'


### PR DESCRIPTION
Correct National Number length for Somalia is 9.
Source: https://en.wikipedia.org/wiki/Telephone_numbers_in_Somalia

Fixes: https://github.com/countries/countries/issues/955