### PR TITLE
Fix four IN subdivision names: TS, UK, PY, DH

### DIFF
--- a/lib/countries/data/subdivisions/IN.yaml
+++ b/lib/countries/data/subdivisions/IN.yaml
@@ -649,7 +649,7 @@ CG:
   type: state
 DH:
   translations:
-    en: Dādra and Nagar Haveli and Damān and Diu
+    en: Dadra and Nagar Haveli and Daman and Diu
     ar: دادرا وناغار هافيلي ودامان وديو
     as: দাদৰা আৰু নগৰ হাভেলী আৰু দমন আৰু দিউ
     be: Дадра і Нагархавелі і Даман і Дыу
@@ -679,7 +679,7 @@ DH:
     th: ดาดราและนครหเวลี และดามันและดีอู
     ur: دادرا و نگر حویلی و دمن و دیو
     vi: Dadra và Nagar Haveli và Daman và Diu
-  name: Dādra and Nagar Haveli and Damān and Diu
+  name: Dadra and Nagar Haveli and Daman and Diu
   code: DH
   type: union_territory
 DL:
@@ -2407,7 +2407,7 @@ PB:
     ha_NE: Punjab (Indiya)
   type: state
 PY:
-  name: Pondicherry
+  name: Puducherry
   code: PY
   unofficial_names:
   - Pondicherry
@@ -2680,7 +2680,7 @@ SK:
     uz: Sekkim
   type: state
 TS:
-  name: तेलंगाना
+  name: Telangana
   code: TS
   translations:
     ar: تيلانغانا
@@ -3037,7 +3037,7 @@ UP:
     sd: اتر پرديش
   type: state
 UK:
-  name: उत्तराखण्ड
+  name: Uttarakhand
   code: UK
   translations:
     ar: أوتاراخند


### PR DESCRIPTION
Fixes #956.

## What

Aligns the top-level `name:` field for four Indian subdivisions in `lib/countries/data/subdivisions/IN.yaml`:

```diff
 TS:
-  name: तेलंगाना
+  name: Telangana

 UK:
-  name: उत्तराखण्ड
+  name: Uttarakhand

 PY:
-  name: Pondicherry
+  name: Puducherry
   unofficial_names:
   - Pondicherry     # ← historical name preserved here

 DH:
   translations:
-    en: Dādra and Nagar Haveli and Damān and Diu
+    en: Dadra and Nagar Haveli and Daman and Diu
   ...
-  name: Dādra and Nagar Haveli and Damān and Diu
+  name: Dadra and Nagar Haveli and Daman and Diu
```

## Why

- **TS / UK** — every other IN state has English in `name:`; these two had Hindi. Hindi forms already live under `translations.hi` and are unchanged.
- **PY** — official rename from "Pondicherry" to "Puducherry" took effect in 2006 and the gem already carried `translations.en: Puducherry`. The pre-rename label is kept under `unofficial_names` so consumers depending on it still get a hit.
- **DH** — ISO 3166-2:IN's English short name uses simple ASCII ("Dadra and Nagar Haveli and Daman and Diu"). The macron form is a Hindi-to-Latin transliteration; localised scripts (ar, as, hi, etc.) for this subdivision are untouched and remain available via `translations`.

## Verification

```ruby
require 'countries'

ISO3166::Country['IN'].subdivisions['TS'].name   # => "Telangana"
ISO3166::Country['IN'].subdivisions['UK'].name   # => "Uttarakhand"
ISO3166::Country['IN'].subdivisions['PY'].name   # => "Puducherry"
ISO3166::Country['IN'].subdivisions['DH'].name   # => "Dadra and Nagar Haveli and Daman and Diu"

# Untouched:
ISO3166::Country['IN'].subdivisions['TS'].translations['hi']   # => "तेलंगाना"
ISO3166::Country['IN'].subdivisions['UK'].translations['hi']   # => "उत्तराखण्ड"
ISO3166::Country['IN'].subdivisions['PY'].unofficial_names     # => ["Pondicherry"]
```

YAML still parses; all 36 IN subdivisions load.