### PR TITLE
Anchor postal_code_format with \z instead of \Z so a trailing newline is rejected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+* Anchor `postal_code_format` with `\z` instead of `\Z` so the generated regex no longer accepts a trailing newline (e.g. `"123456\n"` is now correctly rejected). Fixes #902
+
 ## [8.1.0](https://github.com/countries/countries/releases/tag/v8.1.0') (2026/01/02 09:14 +00:00)
 
 * Update Romania standard VAT from 19% to 21% + single reduced rate to 11% (Aug 1st 2025 change) by @jarthod in https://github.com/countries/countries/pull/930

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -117,7 +117,7 @@ module ISO3166
 
     # @return [String] The regex for valid postal codes in this Country
     def postal_code_format
-      "\\A#{data['postal_code_format']}\\Z" if postal_code
+      "\\A#{data['postal_code_format']}\\z" if postal_code
     end
 
     def to_s

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -106,6 +106,8 @@ describe ISO3166::Country do
     regex = Regexp.new(country.postal_code_format)
     expect(regex).to match('12345-6789')
     expect(regex).not_to match('12345-67890')
+    # Anchored with \z (not \Z) so a trailing newline is rejected. Fixes #902
+    expect(regex).not_to match("12345-6789\n")
 
     antarctica = ISO3166::Country.search('AQ')
     expect(antarctica.postal_code_format).to be_nil


### PR DESCRIPTION
Fixes #902