### PR TITLE
Don't mutate caller's translations hash in Data.register. Use transform_keys instead of transform_keys!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Unreleased
 
 * Anchor `postal_code_format` with `\z` instead of `\Z` so the generated regex no longer accepts a trailing newline (e.g. `"123456\n"` is now correctly rejected). Fixes #902
+* `ISO3166::Data.register` no longer mutates the `translations` hash passed by the caller (it was transforming the caller's keys to symbols in place)
 
 ## [8.1.0](https://github.com/countries/countries/releases/tag/v8.1.0') (2026/01/02 09:14 +00:00)
 

--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -31,8 +31,7 @@ module ISO3166
       def register(data)
         alpha2 = data[:alpha2].upcase
         @registered_data[alpha2] = deep_stringify_keys(data.except('translations', :translations))
-        translations = data['translations'] || data[:translations] || {}
-        translations.transform_keys!(&:to_sym)
+        translations = (data['translations'] || data[:translations] || {}).transform_keys(&:to_sym)
         @registered_data[alpha2]['translations'] = Translations.new.merge(translations)
         @cache = cache.merge(@registered_data)
       end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -210,6 +210,12 @@ describe ISO3166::Data do
       expect(data).to include('subregion')
     end
 
+    it 'does not mutate the translations hash passed by the caller' do
+      translations = { 'en' => 'Happy Country', 'de' => 'glückliches Land' }
+      ISO3166::Data.register(alpha2: 'LOL', iso_short_name: 'Happy Country', translations: translations)
+      expect(translations.keys).to eq(%w[en de])
+    end
+
     it 'can be undone' do
       ISO3166::Data.unregister('lol')
       data = ISO3166::Data.new('LOL').call


### PR DESCRIPTION
`ISO3166::Data.register`  used `transform_keys!` on the translations hash passed by the caller, turning its string keys into symbols in place. 

Use the non-mutating `transform_keys` so the caller's hash is not modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `ISO3166::Data.register` now leaves the caller’s `translations` hash unchanged, avoiding unexpected side effects when registering data.
  * Data registration handling is now more predictable when translations are provided or omitted.

* **Tests**
  * Added coverage to verify translation hashes are not modified during data registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->