### PR TITLE
Fix overly-large regex range [A-z] in country_spec flagged by CodeQL (rb/overly-large-range, alert #2)

### DIFF
--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -1357,7 +1357,7 @@ describe ISO3166::Country do
     it 'should return country if not convertible input given' do
       expect do
         ISO3166::Country(42)
-      end.to raise_error(TypeError, /can't convert ([A-z]+) into ISO3166::Country/)
+      end.to raise_error(TypeError, /can't convert ([A-Za-z]+) into ISO3166::Country/)
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated error-message matching in country-related test coverage to better validate conversion failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->