### PR TITLE
Update Nauru official name to Naoero

### DIFF
--- a/lib/countries/data/countries/NR.yaml
+++ b/lib/countries/data/countries/NR.yaml
@@ -23,8 +23,8 @@ NR:
         lng: 166.9071293
   international_prefix: '00'
   ioc: NRU
-  iso_long_name: The Republic of Nauru
-  iso_short_name: Nauru
+  iso_long_name: The Republic of Naoero
+  iso_short_name: Naoero
   languages_official:
   - en
   - na


### PR DESCRIPTION
## Summary

Update Nauru’s official country names following its change of name to Naoero.

- `iso_short_name`: `Nauru` → `Naoero`
- `iso_long_name`: `The Republic of Nauru` → `The Republic of Naoero`

The change is limited to `lib/countries/data/countries/NR.yaml`. Existing unofficial names remain unchanged so that `Nauru` continues to be available as an alternative name.

## Sources

- [United Nations Member State: Naoero](https://www.un.org/en/about-us/member-states/naoero)
- [Republic of Naoero Government Gazette No. 223, 26 June 2026](https://ronlaw.gov.nr/assets/docs%2Fgazettes%2F2026%2FGazette%20No.%20223.2026%20%2826%20June%202026%29.pdf)

## Testing

```text
bundle exec rake
280 examples, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the displayed country names for Nauru to “The Republic of Naoero” and “Naoero” in country data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->